### PR TITLE
Add #idea# note type with AI expansion feature (Vibe Kanban)

### DIFF
--- a/Services/LLMService.swift
+++ b/Services/LLMService.swift
@@ -261,6 +261,31 @@ final class LLMService: NSObject {
         }
     }
 
+    /// Expand a brief idea/thought into a fuller developed concept
+    func expandIdea(_ idea: String) async throws -> String {
+        let prompt = """
+        You are helping expand a brief handwritten note or idea into a fuller thought. The user quickly jotted this down and wants help developing it.
+
+        Please:
+        1. Expand the idea into 2-3 well-developed paragraphs
+        2. Keep the original intent and meaning
+        3. Add context, implications, or potential applications
+        4. Use clear, accessible language
+        5. Don't add unnecessary filler - focus on substance
+        6. If it's a question, explore possible answers
+        7. If it's a concept, explain it more fully
+        8. If it's a task idea, elaborate on potential approaches
+
+        Original idea:
+        \(idea)
+
+        Return ONLY the expanded thought. No explanations, headers, or meta-commentary.
+        """
+
+        let expandedText = try await performAPIRequest(prompt: prompt, maxTokens: 1024)
+        return expandedText.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     /// Generate a summary of the note content
     func summarizeNote(_ content: String, noteType: String, length: SummaryLength) async throws -> String {
         let prompt = buildSummaryPrompt(for: content, noteType: noteType, length: length)

--- a/Services/TextClassifier.swift
+++ b/Services/TextClassifier.swift
@@ -55,6 +55,14 @@ class TextClassifier {
             }
         }
 
+        // Idea triggers
+        let ideaTriggers = ["#idea#", "#thought#", "#note-to-self#", "#notetoself#"]
+        for trigger in ideaTriggers {
+            if prefix.contains(trigger) {
+                return .idea
+            }
+        }
+
         // Todo triggers
         let todoTriggers = ["#todo#", "#to-do#", "#tasks#", "#task#"]
         for trigger in todoTriggers {
@@ -106,6 +114,19 @@ class TextClassifier {
             }
         }
 
+        // Idea patterns - handle OCR errors
+        let ideaPatterns = [
+            "#idea#", "#ideaa#", "#1dea#", "#ldea#",
+            "#thought#", "#thoughtt#", "#thouqht#", "#thoughl#",
+            "#note-to-self#", "#notetoself#", "#note2self#",
+            "#idea", "idea#", "#thought", "thought#"
+        ]
+        for pattern in ideaPatterns {
+            if normalized.contains(pattern.replacingOccurrences(of: " ", with: "")) {
+                return .idea
+            }
+        }
+
         // Todo patterns - handle common OCR errors
         let todoPatterns = [
             "#todo#", "#tod0#", "#todoo#", "#toDo#",
@@ -147,6 +168,9 @@ class TextClassifier {
         // This catches "# email" or "#email tt" type errors
         if matchesLoosePattern(normalized, keywords: ["claude", "feature", "prompt", "request", "issue"]) {
             return .claudePrompt
+        }
+        if matchesLoosePattern(normalized, keywords: ["idea", "thought", "notetoself"]) {
+            return .idea
         }
         if matchesLoosePattern(normalized, keywords: ["email", "mail", "emai", "ernail"]) {
             return .email
@@ -238,6 +262,7 @@ class TextClassifier {
     func extractTriggerTag(from content: String) -> (tag: String, cleanedContent: String)? {
         let patterns = [
             "#claude#", "#feature#", "#prompt#", "#request#", "#issue#",
+            "#idea#", "#thought#", "#note-to-self#", "#notetoself#",
             "#todo#", "#to-do#", "#tasks#", "#task#",
             "#email#", "#mail#",
             "#meeting#", "#notes#", "#minutes#"
@@ -270,6 +295,7 @@ enum NoteType: String {
     case meeting = "meeting"
     case email = "email"
     case claudePrompt = "claudePrompt"
+    case idea = "idea"
 
     var displayName: String {
         switch self {
@@ -278,6 +304,7 @@ enum NoteType: String {
         case .meeting: return "Meeting"
         case .email: return "Email"
         case .claudePrompt: return "Prompt"
+        case .idea: return "Idea"
         }
     }
 
@@ -288,6 +315,7 @@ enum NoteType: String {
         case .meeting: return "calendar"
         case .email: return "envelope"
         case .claudePrompt: return "sparkles"
+        case .idea: return "lightbulb"
         }
     }
 
@@ -298,6 +326,7 @@ enum NoteType: String {
         case .meeting: return "badgeMeeting"
         case .email: return "badgeEmail"
         case .claudePrompt: return "badgePrompt"
+        case .idea: return "badgeIdea"
         }
     }
 }

--- a/Utilities/Extensions.swift
+++ b/Utilities/Extensions.swift
@@ -124,6 +124,7 @@ extension Color {
     static let badgeGeneral = Color(red: 30/255, green: 77/255, blue: 47/255)      // #1e4d2f - forest
     static let badgeEmail = Color(red: 139/255, green: 69/255, blue: 119/255)      // #8b4577 - plum
     static let badgePrompt = Color(red: 91/255, green: 77/255, blue: 153/255)      // #5b4d99 - purple
+    static let badgeIdea = Color(red: 230/255, green: 168/255, blue: 56/255)       // #e6a838 - amber/lightbulb
 
     // App-wide theme colors (for compatibility)
     static let appPrimary = forestDark

--- a/Views/Components/DetailHeader.swift
+++ b/Views/Components/DetailHeader.swift
@@ -155,6 +155,8 @@ struct DetailHeader: View {
         case "todo": return .badgeTodo
         case "meeting": return .badgeMeeting
         case "email": return .badgeEmail
+        case "idea": return .badgeIdea
+        case "claudeprompt": return .badgePrompt
         default: return .badgeGeneral
         }
     }

--- a/Views/Notes/IdeaDetailView.swift
+++ b/Views/Notes/IdeaDetailView.swift
@@ -1,0 +1,574 @@
+//
+//  IdeaDetailView.swift
+//  QuillStack
+//
+//  Created on 2025-12-31.
+//
+
+import SwiftUI
+import CoreData
+
+struct IdeaDetailView: View {
+    @ObservedObject var note: Note
+    @State private var editedContent: String = ""
+    @State private var expandedIdea: String = ""
+    @State private var isExpanding: Bool = false
+    @State private var expandError: String?
+    @State private var showingExpandSheet: Bool = false
+    @State private var showingExportSheet: Bool = false
+    @State private var tags: [String] = []
+    @State private var newTag: String = ""
+    @ObservedObject private var settings = SettingsManager.shared
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        ZStack {
+            Color.creamLight.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                slimHeader
+
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 20) {
+                        // Original idea section
+                        originalIdeaSection
+
+                        // Tags section
+                        tagsSection
+
+                        // Expanded idea section (if available)
+                        if !expandedIdea.isEmpty {
+                            expandedIdeaSection
+                        }
+                    }
+                    .padding(20)
+                }
+                .background(contentBackground)
+
+                bottomBar
+            }
+        }
+        .navigationBarHidden(true)
+        .onAppear {
+            editedContent = note.content
+            expandedIdea = note.summary ?? ""
+            loadTags()
+        }
+        .onChange(of: editedContent) { _, newValue in
+            if newValue != note.content {
+                saveChanges()
+            }
+        }
+        .sheet(isPresented: $showingExpandSheet) {
+            expandSheet
+        }
+        .sheet(isPresented: $showingExportSheet) {
+            ExportSheet(note: note)
+                .presentationDetents([.medium, .large])
+        }
+    }
+
+    // MARK: - Content Background
+
+    private var contentBackground: some View {
+        LinearGradient(
+            colors: [Color.paperBeige.opacity(0.98), Color.paperTan.opacity(0.98)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+        )
+    }
+
+    // MARK: - Original Idea Section
+
+    private var originalIdeaSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "lightbulb.fill")
+                    .foregroundColor(.badgeIdea)
+                Text("Quick Capture")
+                    .font(.serifBody(15, weight: .semibold))
+                    .foregroundColor(.textMedium)
+            }
+
+            TextEditor(text: $editedContent)
+                .font(.serifBody(17, weight: .regular))
+                .foregroundColor(.textDark)
+                .lineSpacing(6)
+                .scrollContentBackground(.hidden)
+                .frame(minHeight: 100)
+                .padding(12)
+                .background(Color.white.opacity(0.5))
+                .cornerRadius(8)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.badgeIdea.opacity(0.3), lineWidth: 1)
+                )
+        }
+    }
+
+    // MARK: - Tags Section
+
+    private var tagsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "tag")
+                    .foregroundColor(.textMedium)
+                Text("Tags")
+                    .font(.serifBody(15, weight: .semibold))
+                    .foregroundColor(.textMedium)
+            }
+
+            FlowLayout(spacing: 8) {
+                ForEach(tags, id: \.self) { tag in
+                    tagChip(tag)
+                }
+                addTagButton
+            }
+        }
+    }
+
+    private func tagChip(_ tag: String) -> some View {
+        HStack(spacing: 4) {
+            Text("#\(tag)")
+                .font(.serifCaption(13, weight: .medium))
+                .foregroundColor(.forestDark)
+
+            Button(action: { removeTag(tag) }) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .bold))
+                    .foregroundColor(.forestDark.opacity(0.6))
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color.forestLight.opacity(0.5))
+        .cornerRadius(12)
+    }
+
+    private var addTagButton: some View {
+        HStack(spacing: 4) {
+            if !newTag.isEmpty {
+                TextField("Tag", text: $newTag)
+                    .font(.serifCaption(13, weight: .medium))
+                    .foregroundColor(.forestDark)
+                    .frame(width: 80)
+                    .onSubmit {
+                        addTag()
+                    }
+
+                Button(action: addTag) {
+                    Image(systemName: "checkmark")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundColor(.forestDark)
+                }
+            } else {
+                Button(action: { newTag = " " }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "plus")
+                            .font(.system(size: 10, weight: .bold))
+                        Text("Add Tag")
+                            .font(.serifCaption(13, weight: .medium))
+                    }
+                    .foregroundColor(.forestDark.opacity(0.7))
+                }
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color.forestDark.opacity(0.1))
+        .cornerRadius(12)
+    }
+
+    // MARK: - Expanded Idea Section
+
+    private var expandedIdeaSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: "sparkles")
+                    .foregroundColor(.badgeIdea)
+                Text("Expanded Thought")
+                    .font(.serifBody(15, weight: .semibold))
+                    .foregroundColor(.textMedium)
+                Spacer()
+                Button(action: { expandedIdea = "" }) {
+                    Image(systemName: "xmark.circle")
+                        .foregroundColor(.textMedium.opacity(0.6))
+                }
+            }
+
+            Text(expandedIdea)
+                .font(.serifBody(16, weight: .regular))
+                .foregroundColor(.textDark)
+                .lineSpacing(6)
+                .padding(12)
+                .background(Color.badgeIdea.opacity(0.1))
+                .cornerRadius(8)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(Color.badgeIdea.opacity(0.3), lineWidth: 1)
+                )
+        }
+    }
+
+    // MARK: - Slim Header
+
+    private var slimHeader: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .center, spacing: 12) {
+                Button(action: { dismiss() }) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundColor(.forestLight)
+                }
+                .accessibilityLabel("Back to notes")
+
+                Text("Idea")
+                    .font(.serifBody(17, weight: .semibold))
+                    .foregroundColor(.forestLight)
+                    .lineLimit(1)
+
+                Spacer()
+
+                noteTypeBadge
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 8)
+            .padding(.bottom, 8)
+
+            HStack(spacing: 12) {
+                Text(note.createdAt.formattedForNotes())
+                    .font(.serifCaption(12, weight: .regular))
+                    .foregroundColor(.textLight.opacity(0.8))
+
+                if !expandedIdea.isEmpty {
+                    Text("•")
+                        .foregroundColor(.textLight.opacity(0.5))
+                    HStack(spacing: 4) {
+                        Image(systemName: "sparkles")
+                            .font(.system(size: 10))
+                        Text("Expanded")
+                            .font(.serifCaption(12, weight: .regular))
+                    }
+                    .foregroundColor(.badgeIdea)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.bottom, 10)
+        }
+        .background(
+            LinearGradient(
+                colors: [Color.forestMedium, Color.forestDark],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .ignoresSafeArea(edges: .top)
+        )
+    }
+
+    // MARK: - Bottom Bar
+
+    private var bottomBar: some View {
+        HStack(spacing: 20) {
+            // Expand with AI (main action)
+            if settings.hasAPIKey {
+                Button(action: { showingExpandSheet = true }) {
+                    HStack(spacing: 6) {
+                        Image(systemName: "sparkles")
+                        Text("Expand")
+                    }
+                    .font(.serifBody(15, weight: .semibold))
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(Color.badgeIdea)
+                    .cornerRadius(8)
+                }
+            }
+
+            Spacer()
+
+            // Export
+            Button(action: { showingExportSheet = true }) {
+                Image(systemName: "arrow.up.doc")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundColor(.textDark)
+            }
+
+            // Share
+            Button(action: shareIdea) {
+                Image(systemName: "square.and.arrow.up")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundColor(.textDark)
+            }
+
+            // Copy
+            Button(action: copyContent) {
+                Image(systemName: "doc.on.clipboard")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundColor(.textDark)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 14)
+        .background(Color.creamLight)
+        .overlay(
+            Rectangle()
+                .fill(Color.forestDark.opacity(0.1))
+                .frame(height: 1),
+            alignment: .top
+        )
+    }
+
+    // MARK: - Expand Sheet
+
+    private var expandSheet: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                if isExpanding {
+                    VStack(spacing: 16) {
+                        ProgressView()
+                            .scaleEffect(1.2)
+                        Text("Expanding your idea...")
+                            .font(.serifBody(15, weight: .medium))
+                            .foregroundColor(.textMedium)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else if let error = expandError {
+                    VStack(spacing: 16) {
+                        Image(systemName: "exclamationmark.triangle")
+                            .font(.system(size: 40))
+                            .foregroundColor(.orange)
+                        Text("Expansion Failed")
+                            .font(.serifHeadline(18, weight: .semibold))
+                            .foregroundColor(.textDark)
+                        Text(error)
+                            .font(.serifBody(14, weight: .regular))
+                            .foregroundColor(.textMedium)
+                            .multilineTextAlignment(.center)
+                        Button("Try Again") {
+                            expandError = nil
+                            performExpansion()
+                        }
+                        .font(.serifBody(15, weight: .semibold))
+                        .foregroundColor(.forestDark)
+                    }
+                    .padding(20)
+                } else {
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text("Expand Idea")
+                            .font(.serifHeadline(20, weight: .semibold))
+                            .foregroundColor(.textDark)
+
+                        Text("Use AI to expand your quick note into a fuller thought. Great for capturing fleeting ideas and developing them later.")
+                            .font(.serifBody(14, weight: .regular))
+                            .foregroundColor(.textMedium)
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Your idea:")
+                                .font(.serifCaption(12, weight: .medium))
+                                .foregroundColor(.textMedium)
+                            Text(editedContent)
+                                .font(.serifBody(15, weight: .regular))
+                                .foregroundColor(.textDark)
+                                .padding(12)
+                                .background(Color.forestLight.opacity(0.3))
+                                .cornerRadius(8)
+                        }
+
+                        Spacer()
+
+                        Button(action: performExpansion) {
+                            HStack {
+                                Image(systemName: "sparkles")
+                                Text("Expand Idea")
+                            }
+                            .font(.serifBody(16, weight: .semibold))
+                            .foregroundColor(.white)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 14)
+                            .background(Color.badgeIdea)
+                            .cornerRadius(10)
+                        }
+                    }
+                    .padding(20)
+                }
+            }
+            .background(Color.creamLight)
+            .navigationTitle("AI Expansion")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        showingExpandSheet = false
+                        expandError = nil
+                    }
+                    .foregroundColor(.forestDark)
+                }
+            }
+        }
+        .presentationDetents([.medium])
+    }
+
+    // MARK: - Actions
+
+    private func performExpansion() {
+        isExpanding = true
+        expandError = nil
+
+        Task {
+            do {
+                let expanded = try await LLMService.shared.expandIdea(editedContent)
+                await MainActor.run {
+                    expandedIdea = expanded
+                    note.summary = expanded
+                    try? CoreDataStack.shared.saveViewContext()
+                    isExpanding = false
+                    showingExpandSheet = false
+                }
+            } catch {
+                await MainActor.run {
+                    expandError = error.localizedDescription
+                    isExpanding = false
+                }
+            }
+        }
+    }
+
+    private func saveChanges() {
+        note.content = editedContent
+        note.updatedAt = Date()
+        saveTags()
+        try? CoreDataStack.shared.saveViewContext()
+    }
+
+    private func loadTags() {
+        // Load tags from note.tags (stored as comma-separated string)
+        if let tagString = note.tags, !tagString.isEmpty {
+            tags = tagString.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        }
+    }
+
+    private func saveTags() {
+        note.tags = tags.joined(separator: ",")
+    }
+
+    private func addTag() {
+        let tag = newTag.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !tag.isEmpty && !tags.contains(tag) {
+            tags.append(tag)
+            saveTags()
+        }
+        newTag = ""
+    }
+
+    private func removeTag(_ tag: String) {
+        tags.removeAll { $0 == tag }
+        saveTags()
+    }
+
+    private func shareIdea() {
+        var content = editedContent
+        if !expandedIdea.isEmpty {
+            content += "\n\n---\nExpanded:\n\(expandedIdea)"
+        }
+        if !tags.isEmpty {
+            content += "\n\nTags: " + tags.map { "#\($0)" }.joined(separator: " ")
+        }
+
+        let activityVC = UIActivityViewController(
+            activityItems: [content],
+            applicationActivities: nil
+        )
+
+        if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+           let window = windowScene.windows.first,
+           let rootViewController = window.rootViewController {
+            rootViewController.present(activityVC, animated: true)
+        }
+    }
+
+    private func copyContent() {
+        var content = editedContent
+        if !expandedIdea.isEmpty {
+            content += "\n\n---\nExpanded:\n\(expandedIdea)"
+        }
+        UIPasteboard.general.string = content
+    }
+
+    // MARK: - Badge
+
+    private var noteTypeBadge: some View {
+        HStack(spacing: 4) {
+            Image(systemName: "lightbulb")
+                .font(.system(size: 10, weight: .bold))
+            Text("IDEA")
+                .font(.system(size: 10, weight: .bold))
+                .tracking(0.5)
+        }
+        .foregroundColor(.white)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(
+            LinearGradient(
+                colors: [Color.badgeIdea, Color.badgeIdea.opacity(0.85)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .cornerRadius(4)
+        .shadow(color: Color.badgeIdea.opacity(0.3), radius: 2, x: 0, y: 1)
+    }
+}
+
+// MARK: - Flow Layout for Tags
+
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let result = FlowResult(in: proposal.width ?? 0, subviews: subviews, spacing: spacing)
+        return result.size
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let result = FlowResult(in: bounds.width, subviews: subviews, spacing: spacing)
+        for (index, subview) in subviews.enumerated() {
+            subview.place(at: CGPoint(x: bounds.minX + result.positions[index].x,
+                                      y: bounds.minY + result.positions[index].y),
+                         proposal: .unspecified)
+        }
+    }
+
+    struct FlowResult {
+        var size: CGSize = .zero
+        var positions: [CGPoint] = []
+
+        init(in maxWidth: CGFloat, subviews: Subviews, spacing: CGFloat) {
+            var x: CGFloat = 0
+            var y: CGFloat = 0
+            var rowHeight: CGFloat = 0
+
+            for subview in subviews {
+                let size = subview.sizeThatFits(.unspecified)
+
+                if x + size.width > maxWidth && x > 0 {
+                    x = 0
+                    y += rowHeight + spacing
+                    rowHeight = 0
+                }
+
+                positions.append(CGPoint(x: x, y: y))
+                rowHeight = max(rowHeight, size.height)
+                x += size.width + spacing
+            }
+
+            self.size = CGSize(width: maxWidth, height: y + rowHeight)
+        }
+    }
+}
+
+#Preview {
+    IdeaDetailView(note: Note())
+}

--- a/Views/Notes/NoteListView.swift
+++ b/Views/Notes/NoteListView.swift
@@ -240,6 +240,8 @@ struct NoteListView: View {
             MeetingDetailView(note: note)
         case "claudeprompt":
             ClaudePromptDetailView(note: note)
+        case "idea":
+            IdeaDetailView(note: note)
         default:
             NoteDetailView(note: note)
         }
@@ -372,6 +374,7 @@ struct NoteCardView: View {
         case "meeting": return "calendar"
         case "email": return "envelope"
         case "claudeprompt": return "sparkles"
+        case "idea": return "lightbulb"
         default: return "doc.text"
         }
     }
@@ -382,6 +385,7 @@ struct NoteCardView: View {
         case "meeting": return .badgeMeeting
         case "email": return .badgeEmail
         case "claudeprompt": return .badgePrompt
+        case "idea": return .badgeIdea
         default: return .badgeGeneral
         }
     }
@@ -422,6 +426,8 @@ struct NoteCardView: View {
             return "paperplane"
         case "claudeprompt":
             return "arrow.up.circle"
+        case "idea":
+            return "sparkles"
         default:
             return "text.alignleft"
         }
@@ -439,6 +445,8 @@ struct NoteCardView: View {
             return "Draft"
         case "claudeprompt":
             return note.summary != nil ? "Issue created" : "Ready to export"
+        case "idea":
+            return note.summary != nil ? "Expanded" : "Quick capture"
         default:
             let wordCount = note.content.components(separatedBy: .whitespacesAndNewlines).filter { !$0.isEmpty }.count
             return "\(wordCount) words"


### PR DESCRIPTION
## Summary

Implements the `#idea#` note type for quick capture of thoughts and ideas with AI-powered expansion.

## Changes Made

### New Files
- **`Views/Notes/IdeaDetailView.swift`** - New detail view for idea notes featuring:
  - Editable original idea section with quick capture display
  - Tags system with flow layout for organizing ideas
  - AI expansion feature that develops brief notes into fuller thoughts
  - Share/copy functionality that includes both original and expanded content

### Modified Files
- **`Services/TextClassifier.swift`**
  - Added `idea` case to `NoteType` enum
  - Added trigger detection for `#idea#`, `#thought#`, `#note-to-self#`, `#notetoself#`
  - Added fuzzy OCR patterns for common misreads (e.g., `#1dea#`, `#ldea#`, `#thouqht#`)
  - Added loose pattern matching fallback

- **`Services/LLMService.swift`**
  - Added `expandIdea()` method that uses Claude API to expand brief notes into 2-3 developed paragraphs

- **`Utilities/Extensions.swift`**
  - Added `badgeIdea` color (amber #e6a838) for consistent theming

- **`Views/Notes/NoteListView.swift`**
  - Added routing to `IdeaDetailView` for idea notes
  - Added lightbulb icon and amber badge color
  - Added footer status showing "Expanded" or "Quick capture"

- **`Views/Components/DetailHeader.swift`**
  - Added badge color support for idea and claudePrompt types

## Features

| Trigger Tags | Action | Key Features |
|-------------|--------|--------------|
| `#idea#`, `#thought#`, `#note-to-self#` | Quick capture with AI expansion | LLM expands brief notes into fuller thoughts, tags for retrieval |

## Implementation Details

- The AI expansion uses a focused prompt that develops ideas while preserving original intent
- Tags are stored as comma-separated strings in the note's `tags` field
- Expanded content is stored in the note's `summary` field for persistence
- FlowLayout custom layout provides responsive tag chip arrangement

---

*This PR was written using [Vibe Kanban](https://vibekanban.com)*