### PR TITLE
Ocr correction key compliance

### DIFF
--- a/ViewModels/StatisticsViewModel.swift
+++ b/ViewModels/StatisticsViewModel.swift
@@ -160,29 +160,21 @@ class StatisticsViewModel: ObservableObject {
     }
 
     private func fetchLearningStats() -> LearningStats {
-        let request = NSFetchRequest<NSManagedObject>(entityName: "OCRCorrection")
+        let request = NSFetchRequest<OCRCorrection>(entityName: "OCRCorrection")
 
         do {
             let corrections = try context.fetch(request)
-            let totalCorrections = corrections.count
-
-            // Find most frequent correction
-            var mostFrequent: (original: String, corrected: String, count: Int)?
-            for correction in corrections {
-                if let original = correction.value(forKey: "originalText") as? String,
-                   let corrected = correction.value(forKey: "correctedText") as? String,
-                   let frequency = correction.value(forKey: "frequency") as? Int {
-                    if mostFrequent == nil || frequency > mostFrequent!.count {
-                        mostFrequent = (original, corrected, frequency)
-                    }
-                }
+            guard !corrections.isEmpty else {
+                return LearningStats()
             }
 
+            let mostFrequent = corrections.max(by: { $0.frequency < $1.frequency })
+
             return LearningStats(
-                totalCorrections: totalCorrections,
-                mostFrequentOriginal: mostFrequent?.original,
-                mostFrequentCorrected: mostFrequent?.corrected,
-                mostFrequentCount: mostFrequent?.count ?? 0
+                totalCorrections: corrections.count,
+                mostFrequentOriginal: mostFrequent?.originalWord,
+                mostFrequentCorrected: mostFrequent?.correctedWord,
+                mostFrequentCount: mostFrequent.map { Int($0.frequency) } ?? 0
             )
         } catch {
             print("Failed to fetch learning stats: \(error)")


### PR DESCRIPTION
### **User description**
Fixes `NSUnknownKeyException` by using strongly typed `NSFetchRequest` and correct Core Data attributes (`originalWord`, `correctedWord`) instead of non-existent KVC keys.

---
Linear Issue: [QUI-53](https://linear.app/quillstack/issue/QUI-53/nsunknownkeyexception-ocrcorrection-0x152d2c640-valueforundefinedkey)

<a href="https://cursor.com/background-agent?bcId=bc-37924005-9bc8-40c2-873a-5bebf99a47d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-37924005-9bc8-40c2-873a-5bebf99a47d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed `NSUnknownKeyException` by using correct Core Data attribute names
  - Changed `originalText` to `originalWord` and `correctedText` to `correctedWord`

- Refactored `fetchLearningStats()` to use strongly typed `NSFetchRequest<OCRCorrection>`

- Simplified most frequent correction logic using `max(by:)` instead of manual loop

- Improved code readability and type safety with direct property access


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NSFetchRequest<NSManagedObject>"] -->|"Use strongly typed"| B["NSFetchRequest<OCRCorrection>"]
  C["KVC keys: originalText, correctedText"] -->|"Use correct attributes"| D["originalWord, correctedWord"]
  E["Manual loop to find max"] -->|"Refactor to"| F["max(by:) function"]
  B --> G["Type-safe LearningStats"]
  D --> G
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>StatisticsViewModel.swift</strong><dd><code>Refactor fetchLearningStats with type safety and correct attributes</code></dd></summary>
<hr>

ViewModels/StatisticsViewModel.swift

<ul><li>Changed <code>NSFetchRequest<NSManagedObject></code> to <code>NSFetchRequest<OCRCorrection></code> for type safety<br> <li> Fixed KVC key names from <code>originalText</code>/<code>correctedText</code> to <br><code>originalWord</code>/<code>correctedWord</code><br> <li> Replaced manual loop with <code>max(by:)</code> to find most frequent correction<br> <li> Added early return guard for empty corrections array<br> <li> Simplified property access using direct typed attributes instead of <br><code>value(forKey:)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/mikemott/QuillStack/pull/9/files#diff-adbd61bae7b6b67bb1a6726df54c94f1fc4e787939e6b0882bb2eba648c8c7d2">+9/-17</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors learning stats to use strongly-typed Core Data access and correct model attributes.
> 
> - Updates `fetchLearningStats` to `NSFetchRequest<OCRCorrection>` and replaces KVC with direct properties
> - Computes most frequent correction via `max(by:)` on `frequency` and maps to `LearningStats`
> - Uses `originalWord`/`correctedWord` attributes and safely returns empty stats when no corrections exist
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96cb0d2d5ac35684fea55422f3958522fa09e46c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->