### PR TITLE
Add credit usage warning in Settings UI

### DIFF
--- a/Views/Settings/SettingsView.swift
+++ b/Views/Settings/SettingsView.swift
@@ -255,7 +255,9 @@ struct SettingsView: View {
                         .padding(.top, 4)
 
                         // Low credits warning
-                        if let usage = settings.creditUsagePercentage(), usage > 0.8 {
+                        if settings.betaCreditsTotal > 0,
+                           let usage = settings.creditUsagePercentage(),
+                           usage > 0.8 {
                             HStack(spacing: 8) {
                                 Image(systemName: "exclamationmark.triangle.fill")
                                     .font(.system(size: 12))
@@ -1078,6 +1080,10 @@ struct SettingsView: View {
     private func saveBetaCode() {
         settings.betaCode = betaCodeInput
         settings.useBetaAPIProxy = true
+
+        // Reset credits when changing beta codes to prevent stale display
+        settings.betaCreditsRemaining = 0
+        settings.betaCreditsTotal = 0
 
         // Set default proxy URL if not already set
         if settings.betaAPIProxyURL == nil {


### PR DESCRIPTION
### **User description**
## Summary
Adds a visual warning banner in Settings when beta credits usage exceeds 80%.

## Changes
- Added credit usage warning banner below credits display
- Shows when `creditUsagePercentage() > 0.8` (less than 20% remaining)
- Orange color scheme with warning icon
- Displays current usage percentage and helpful message
- Only visible when using beta code

## Implementation Details
- Uses `SettingsManager.creditUsagePercentage()` helper method
- Follows app design system (serif fonts, rounded corners, soft colors)
- Conditionally rendered within existing beta code section

## Screenshot
Warning appears when credits < 20% remaining with percentage and message.

Closes QUI-68


___

### **PR Type**
Enhancement


___

### **Description**
- Add beta code authentication as alternative to API keys

- Display credit usage warning when beta credits exceed 80%

- Implement debug tools section for crash testing in DEBUG builds

- Refactor Settings UI with custom header and gradient backgrounds

- Add Sentry integration for error tracking and debugging


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Settings View"] --> B["Beta Code Entry"]
  B --> C["Credits Display"]
  C --> D["Low Credits Warning"]
  A --> E["Debug Section"]
  E --> F["Test Crash Button"]
  E --> G["Send Test Event"]
  A --> H["UI Refactoring"]
  H --> I["Custom Header"]
  H --> J["Gradient Backgrounds"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SettingsView.swift</strong><dd><code>Beta code support, credit warnings, and debug tools</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Views/Settings/SettingsView.swift

<ul><li>Added beta code entry section with optional toggle and save/clear <br>buttons<br> <li> Implemented credit usage warning banner showing when usage exceeds 80%<br> <li> Added debug section (DEBUG builds only) with crash testing and Sentry <br>event sending<br> <li> Refactored Settings layout with custom PageHeader and gradient <br>backgrounds for all sections<br> <li> Updated AI features availability check to use <code>canUseAIFeatures</code> instead <br>of just <code>hasAPIKey</code><br> <li> Added Sentry import and integrated breadcrumb/event tracking in debug <br>tools<br> <li> Changed section backgrounds from solid white to gradient (paperBeige <br>to paperTan)<br> <li> Enhanced shadow opacity from 0.05 to 0.08 for better visual hierarchy</ul>


</details>


  </td>
  <td><a href="https://github.com/mikemott/QuillStack/pull/11/files#diff-34872b0370c784fb3b0e168edb9dad5b052c4c68acf664dc80bce2c37ce91020">+322/-37</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

<!-- CURSOR_SUMMARY -->
> [!NOTE]
> - Introduces optional `betaCode` input with save/clear actions; sets default proxy URL, resets credits on change, and displays remaining credits with a low-credits warning when `creditUsagePercentage() > 0.8`.
> - Adds DEBUG-only "Debug Tools" section: trigger a test crash and send a test event to Sentry (imports Sentry, adds breadcrumb before crash).
> - Refreshes `SettingsView` layout: custom `PageHeader`, hides navigation bar, and applies gradient backgrounds with stronger shadows across all sections.
> - Updates AI feature gating to use `settings.canUseAIFeatures` instead of `hasAPIKey` for enabling controls.
> - Minor helpers: `saveBetaCode()`/`clearBetaCode()` implementations and related state wiring; non-functional styling tweaks and dividers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6cf7e251afb5bb2897465e66e80028f3ff8b3fb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->