### PR TITLE
Voice memo transcription enhancement

### DIFF
--- a/QuillStack.xcodeproj/project.pbxproj
+++ b/QuillStack.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		30B2A2DC36408817230AE3E2 /* CalendarServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E21F9CA4CFBAB20368840C /* CalendarServiceProtocol.swift */; };
 		3E065E96161C05869F566CC7 /* LLMServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A8EB6B4089DB1C6BA238A7 /* LLMServiceProtocol.swift */; };
 		546B770950DD133042920854 /* StatisticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C297376A19DEB99BDF5675 /* StatisticsViewModel.swift */; };
+		AA16C8BF2FA0C5F700000001 /* VoiceMemoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA16C8BE2FA0C5F700000001 /* VoiceMemoViewModel.swift */; };
 		60221FB0AB9940FC245F4D39 /* RemindersServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6EF8D919607450456C9B843 /* RemindersServiceProtocol.swift */; };
 		7F8AFA2A88D58A9D9729204B /* DetailViewFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 135689AE59463E16DB510DA6 /* DetailViewFactory.swift */; };
 		8CC9CAC1B76D51B8129A8E61 /* TypeGuideView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6CBC205145101FF179EBE6E /* TypeGuideView.swift */; };
@@ -170,6 +171,7 @@
 		2796C1962EEB55B900E05291 /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		2796C1972EEB55B900E05291 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		2796C1982EEB55C700E05291 /* CameraViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraViewModel.swift; sourceTree = "<group>"; };
+		AA16C8BE2FA0C5F700000001 /* VoiceMemoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceMemoViewModel.swift; sourceTree = "<group>"; };
 		2796C19A2EEB55C700E05291 /* MeetingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingViewModel.swift; sourceTree = "<group>"; };
 		2796C19B2EEB55C700E05291 /* NoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteViewModel.swift; sourceTree = "<group>"; };
 		2796C19C2EEB55EC00E05291 /* CameraPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CameraPreviewView.swift; sourceTree = "<group>"; };
@@ -389,6 +391,7 @@
 			children = (
 				B6C297376A19DEB99BDF5675 /* StatisticsViewModel.swift */,
 				2796C1982EEB55C700E05291 /* CameraViewModel.swift */,
+				AA16C8BE2FA0C5F700000001 /* VoiceMemoViewModel.swift */,
 				2796C19A2EEB55C700E05291 /* MeetingViewModel.swift */,
 				2796C19B2EEB55C700E05291 /* NoteViewModel.swift */,
 				F002000000000010 /* SearchViewModel.swift */,
@@ -822,6 +825,7 @@
 				2796C1B42EEB570000E05291 /* Constants.swift in Sources */,
 				2796C1B52EEB570000E05291 /* Extensions.swift in Sources */,
 				2796C1B62EEB570000E05291 /* CameraViewModel.swift in Sources */,
+				AA16C8BF2FA0C5F700000001 /* VoiceMemoViewModel.swift in Sources */,
 				2796C1B82EEB570000E05291 /* MeetingViewModel.swift in Sources */,
 				2796C1B92EEB570000E05291 /* NoteViewModel.swift in Sources */,
 				2796C1BA2EEB570000E05291 /* CameraPreviewView.swift in Sources */,

--- a/ViewModels/VoiceMemoViewModel.swift
+++ b/ViewModels/VoiceMemoViewModel.swift
@@ -1,0 +1,354 @@
+//
+//  VoiceMemoViewModel.swift
+//  QuillStack
+//
+//  Created for QUI-102 to power voice memo capture and transcription.
+//
+
+import Foundation
+import AVFoundation
+import Speech
+import CoreData
+import Combine
+
+@MainActor
+final class VoiceMemoViewModel: ObservableObject {
+    enum SaveState: Equatable {
+        case idle
+        case saving
+        case success(Int)
+        case failure(String)
+    }
+
+    @Published var transcript: String = "" {
+        didSet {
+            if oldValue != transcript {
+                updateDetectedSections()
+                if saveState != .idle {
+                    saveState = .idle
+                }
+            }
+        }
+    }
+
+    @Published private(set) var detectedSections: [NoteSection] = []
+    @Published private(set) var isRecording = false
+    @Published private(set) var isSaving = false
+    @Published var saveState: SaveState = .idle
+    @Published var errorMessage: String?
+    @Published private(set) var microphoneGranted = false
+    @Published private(set) var speechGranted = false
+
+    private let audioEngine = AVAudioEngine()
+    private var audioTapInstalled = false
+    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
+    private var recognitionTask: SFSpeechRecognitionTask?
+    private let speechRecognizer: SFSpeechRecognizer?
+    private let textClassifier: TextClassifierProtocol
+    private var manualPrefix: String = ""
+
+    init(
+        locale: Locale = Locale.autoupdatingCurrent,
+        textClassifier: TextClassifierProtocol? = nil
+    ) {
+        self.speechRecognizer = SFSpeechRecognizer(locale: locale)
+        self.textClassifier = textClassifier ?? TextClassifier()
+        self.microphoneGranted = AVAudioSession.sharedInstance().recordPermission == .granted
+
+        let currentSpeechStatus = SFSpeechRecognizer.authorizationStatus()
+        self.speechGranted = currentSpeechStatus == .authorized
+    }
+
+    deinit {
+        // Cleanup audio resources on deallocation
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+        if audioTapInstalled {
+            audioEngine.inputNode.removeTap(onBus: 0)
+        }
+        recognitionRequest?.endAudio()
+        recognitionTask?.cancel()
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    // MARK: - Permissions
+
+    func requestPermissions() async {
+        if AVAudioSession.sharedInstance().recordPermission == .undetermined {
+            microphoneGranted = await requestMicrophoneAuthorization()
+        } else {
+            microphoneGranted = AVAudioSession.sharedInstance().recordPermission == .granted
+        }
+
+        let currentStatus = SFSpeechRecognizer.authorizationStatus()
+        if currentStatus == .notDetermined {
+            let newStatus = await requestSpeechAuthorization()
+            speechGranted = newStatus == .authorized
+        } else {
+            speechGranted = currentStatus == .authorized
+        }
+
+        if !microphoneGranted {
+            errorMessage = "Enable microphone access in Settings to record voice memos."
+        } else if !speechGranted {
+            errorMessage = "Enable speech recognition in Settings to transcribe voice memos."
+        }
+    }
+
+    private func requestMicrophoneAuthorization() async -> Bool {
+        await withCheckedContinuation { continuation in
+            AVAudioSession.sharedInstance().requestRecordPermission { granted in
+                continuation.resume(returning: granted)
+            }
+        }
+    }
+
+    private func requestSpeechAuthorization() async -> SFSpeechRecognizerAuthorizationStatus {
+        await withCheckedContinuation { continuation in
+            SFSpeechRecognizer.requestAuthorization { status in
+                continuation.resume(returning: status)
+            }
+        }
+    }
+
+    // MARK: - Recording
+
+    func startRecording() {
+        guard !isRecording else { return }
+        guard microphoneGranted else {
+            errorMessage = "Microphone access is required to capture voice memos."
+            return
+        }
+        guard speechGranted else {
+            errorMessage = "Speech recognition access is required to transcribe voice memos."
+            return
+        }
+        guard let speechRecognizer, speechRecognizer.isAvailable else {
+            errorMessage = "Speech recognition is currently unavailable on this device."
+            return
+        }
+
+        manualPrefix = transcript
+
+        recognitionTask?.cancel()
+        recognitionTask = nil
+        errorMessage = nil
+
+        do {
+            try configureAudioSession()
+
+            let request = SFSpeechAudioBufferRecognitionRequest()
+            request.shouldReportPartialResults = true
+            recognitionRequest = request
+
+            let inputNode = audioEngine.inputNode
+            if audioTapInstalled {
+                inputNode.removeTap(onBus: 0)
+                audioTapInstalled = false
+            }
+            let recordingFormat = inputNode.outputFormat(forBus: 0)
+
+            // Install audio tap with larger buffer for better speech capture
+            // Using 4096 samples for more reliable streaming
+            inputNode.installTap(onBus: 0, bufferSize: 4096, format: recordingFormat) { [weak self] buffer, _ in
+                self?.recognitionRequest?.append(buffer)
+            }
+            audioTapInstalled = true
+
+            recognitionTask = speechRecognizer.recognitionTask(with: request) { [weak self] result, error in
+                guard let self else { return }
+
+                if let result = result {
+                    Task { @MainActor in
+                        let recognized = result.bestTranscription.formattedString
+                        if self.manualPrefix.isEmpty {
+                            self.transcript = recognized
+                        } else {
+                            let separator = self.manualPrefix.hasSuffix("\n") ? "" : "\n\n"
+                            self.transcript = self.manualPrefix + separator + recognized
+                        }
+                        if result.isFinal {
+                            self.finishRecordingSession(cancelTask: false)
+                        }
+                    }
+                }
+
+                if let error = error {
+                    Task { @MainActor in
+                        self.errorMessage = "Transcription failed: \(error.localizedDescription)"
+                        self.finishRecordingSession(cancelTask: true)
+                    }
+                }
+            }
+
+            audioEngine.prepare()
+            try audioEngine.start()
+            isRecording = true
+        } catch {
+            errorMessage = "Unable to start recording: \(error.localizedDescription)"
+            finishRecordingSession(cancelTask: true)
+        }
+    }
+
+    func stopRecording() {
+        finishRecordingSession(cancelTask: false)
+    }
+
+    func resetTranscript() {
+        transcript = ""
+        saveState = .idle
+        errorMessage = nil
+        manualPrefix = ""
+    }
+
+    private func configureAudioSession() throws {
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playAndRecord, mode: .voiceChat, options: [.duckOthers, .allowBluetooth])
+        try session.setActive(true, options: .notifyOthersOnDeactivation)
+    }
+
+    private func finishRecordingSession(cancelTask: Bool) {
+        if audioEngine.isRunning {
+            audioEngine.stop()
+        }
+
+        if audioTapInstalled {
+            audioEngine.inputNode.removeTap(onBus: 0)
+            audioTapInstalled = false
+        }
+
+        recognitionRequest?.endAudio()
+        if cancelTask {
+            recognitionTask?.cancel()
+        }
+
+        recognitionRequest = nil
+        recognitionTask = nil
+        isRecording = false
+        manualPrefix = ""
+
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    }
+
+    // MARK: - Saving
+
+    var canSave: Bool {
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty && !isRecording && !isSaving
+    }
+
+    var permissionWarningMessage: String? {
+        if !microphoneGranted {
+            return "Microphone access is disabled. Enable it in Settings > Privacy > Microphone."
+        }
+        if !speechGranted {
+            return "Speech recognition access is disabled. Enable it in Settings > Privacy > Speech Recognition."
+        }
+        if let speechRecognizer, !speechRecognizer.isAvailable {
+            return "Speech recognition is temporarily unavailable. Try again in a moment."
+        }
+        return nil
+    }
+
+    var canStartRecording: Bool {
+        permissionWarningMessage == nil
+    }
+
+    func saveTranscript() async {
+        guard canSave else {
+            if isRecording {
+                errorMessage = "Stop recording before saving."
+            } else {
+                errorMessage = "Record or type something before saving."
+            }
+            return
+        }
+
+        isSaving = true
+        saveState = .saving
+        errorMessage = nil
+
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sections = textClassifier.splitIntoSections(content: trimmed)
+        let sanitizedSections = sections
+            .map { (type: $0.noteType, content: $0.content.trimmingCharacters(in: .whitespacesAndNewlines)) }
+            .filter { !$0.content.isEmpty }
+
+        guard !sanitizedSections.isEmpty else {
+            saveState = .failure("Nothing to save.")
+            isSaving = false
+            return
+        }
+
+        var savedCount = 0
+
+        for section in sanitizedSections {
+            if await saveNote(text: section.content, noteType: section.type) != nil {
+                savedCount += 1
+            }
+        }
+
+        if savedCount > 0 {
+            saveState = .success(savedCount)
+            transcript = ""
+            manualPrefix = ""
+        } else {
+            saveState = .failure("Failed to save voice memo.")
+        }
+
+        isSaving = false
+    }
+
+    private func saveNote(text: String, noteType: NoteType) async -> UUID? {
+        let context = CoreDataStack.shared.newBackgroundContext()
+
+        return await context.perform {
+            let note = Note.create(
+                in: context,
+                content: text,
+                noteType: noteType.rawValue
+            )
+
+            note.ocrConfidence = 1.0
+            note.updatedAt = Date()
+
+            switch noteType {
+            case .todo:
+                let parser = TodoParser(context: context)
+                _ = parser.parseTodos(from: text, note: note)
+            case .meeting:
+                let parser = MeetingParser(context: context)
+                _ = parser.parseMeeting(from: text, note: note)
+            case .contact:
+                _ = ContactParser.parse(text)
+            case .email, .general, .claudePrompt, .reminder, .expense, .shopping, .recipe, .event, .idea:
+                break
+            }
+
+            do {
+                try CoreDataStack.shared.save(context: context)
+                NotificationCenter.default.post(name: AppConstants.Notifications.noteCreated, object: nil)
+                return note.id
+            } catch {
+                Task { @MainActor in
+                    self.errorMessage = "Failed to save note: \(error.localizedDescription)"
+                }
+                return nil
+            }
+        }
+    }
+
+    // MARK: - Detected Sections
+
+    private func updateDetectedSections() {
+        let trimmed = transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            detectedSections = []
+            return
+        }
+
+        detectedSections = textClassifier.splitIntoSections(content: trimmed)
+    }
+}
+


### PR DESCRIPTION
Enhance voice memo transcription to capture full memos and automatically classify/persist notes based on content.

The `VoiceMemoViewModel` now correctly manages the audio pipeline, using a `manualPrefix` to stitch together partial speech recognition results and prevent loss of earlier words. It also integrates `TextClassifier` to automatically identify and save different note types (e.g., reminders, todos) from the transcribed content.

---
Linear Issue: [QUI-102](https://linear.app/quillstack/issue/QUI-102/voice-memo-code-needs-review)

<a href="https://cursor.com/background-agent?bcId=bc-fd9c1ed4-9b0e-4ebf-b02c-1cfffa281d02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-fd9c1ed4-9b0e-4ebf-b02c-1cfffa281d02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

