### PR TITLE
Fix: Add missing files to Xcode project target

### DIFF
--- a/QuillStack.xcodeproj/project.pbxproj
+++ b/QuillStack.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		061F3C399AA5AF2059F10445 /* BulkExportSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA760FE9DEBAF0EC0BF6A1D2 /* BulkExportSheet.swift */; };
+		0E8B9EEBC4BEFD11CAD58716 /* DateParsingService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05C42B046C56E7232F89EB98 /* DateParsingService.swift */; };
 		0F2FA59BBC1D2C79F0271690 /* TextClassifierProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BE0AE1FBB4428D83C26DA73 /* TextClassifierProtocol.swift */; };
 		125A70BA99AA9323947512F8 /* DependencyContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0750FC1DA17F5BABE085CA /* DependencyContainer.swift */; };
 		171D8FDF19DEB33AE9E56252 /* OCRServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 775095B1C35805CEE7B7369D /* OCRServiceProtocol.swift */; };
@@ -43,9 +44,8 @@
 		2796C1F12EEB800000E05291 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2796C1EF2EEB800000E05291 /* SettingsView.swift */; };
 		29CBCDDE52F823B896AD7A0C /* StatisticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B70B286A2AC36CA436C77ACE /* StatisticsView.swift */; };
 		30B2A2DC36408817230AE3E2 /* CalendarServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6E21F9CA4CFBAB20368840C /* CalendarServiceProtocol.swift */; };
-		3BE2C1EC12DEBD683AF11821 /* ClassificationBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00954D76EE6F75C735DC5D32 /* ClassificationBadge.swift */; };
 		3E065E96161C05869F566CC7 /* LLMServiceProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73A8EB6B4089DB1C6BA238A7 /* LLMServiceProtocol.swift */; };
-		3EDE6B3B9044C334344F6EF6 /* NoteTypePickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF6C22302ED7A73DFD1CA59A /* NoteTypePickerSheet.swift */; };
+		3F0F7AED3A70BDE27E9F49A9 /* EventExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E371EA26DD1A11EEF03D8A3 /* EventExtractor.swift */; };
 		483CB6E94C62664F03E95662 /* NetworkAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF994FFEA388D998DB681214 /* NetworkAvailability.swift */; };
 		546B770950DD133042920854 /* StatisticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6C297376A19DEB99BDF5675 /* StatisticsViewModel.swift */; };
 		546F2F8E7516FB2AB0B1A1EF /* NoteClassification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07232297C49D5ED086A1E66A /* NoteClassification.swift */; };
@@ -57,10 +57,12 @@
 		913ADB2ED128AEA3957A143B /* ClassificationAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC24AFC5058E41E54029CC91 /* ClassificationAnalytics.swift */; };
 		9A479F4FDE276998D94EBE62 /* NoteType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60271B88FC8F3E46581FB9B5 /* NoteType.swift */; };
 		9BF33EFBB8118A83F611C8CC /* PDFExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C04153EA7033D6D21E3919 /* PDFExporter.swift */; };
+		A00952A62E5A5F4244EC6F42 /* ExtractedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = F28251EDDBAFBF35904F5BA9 /* ExtractedEvent.swift */; };
 		A1F6BB9C2F1CFA3A00A1C9D1 /* VoiceMemoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F6BB9B2F1CFA3A00A1C9D1 /* VoiceMemoViewModel.swift */; };
 		A1F6BBA32F1CFA3A00A1C9D1 /* VoiceCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1F6BBA22F1CFA3A00A1C9D1 /* VoiceCaptureView.swift */; };
 		A4F800ABD629E75C845D571E /* LearnedCorrectionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10B01C18510FA7EF4FB1FBA9 /* LearnedCorrectionsView.swift */; };
 		A5AD366FB2D0C8213C51DCF3 /* NoteDetailViewProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2350BDFC29B9C62B7D5FEEA /* NoteDetailViewProtocol.swift */; };
+		AA8C277426330FD77BF879DC /* ExtractedTodo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9810C9B1A07EFD2C73649A6 /* ExtractedTodo.swift */; };
 		C0F27DAF1DF2ED92FF50FD9F /* LearnedCorrectionToast.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7BB40F22B11F93336C736DC /* LearnedCorrectionToast.swift */; };
 		E001000000000001 /* ExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = E002000000000001 /* ExportService.swift */; };
 		E001000000000002 /* ExportDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = E002000000000002 /* ExportDestination.swift */; };
@@ -163,7 +165,9 @@
 
 /* Begin PBXFileReference section */
 		00954D76EE6F75C735DC5D32 /* ClassificationBadge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClassificationBadge.swift; path = Views/Components/ClassificationBadge.swift; sourceTree = "<group>"; };
+		05C42B046C56E7232F89EB98 /* DateParsingService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DateParsingService.swift; path = DateParsingService.swift; sourceTree = "<group>"; };
 		07232297C49D5ED086A1E66A /* NoteClassification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NoteClassification.swift; path = Models/NoteClassification.swift; sourceTree = "<group>"; };
+		0E371EA26DD1A11EEF03D8A3 /* EventExtractor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EventExtractor.swift; path = Extraction/EventExtractor.swift; sourceTree = "<group>"; };
 		10B01C18510FA7EF4FB1FBA9 /* LearnedCorrectionsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LearnedCorrectionsView.swift; sourceTree = "<group>"; };
 		135689AE59463E16DB510DA6 /* DetailViewFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DetailViewFactory.swift; path = Services/DetailViewFactory.swift; sourceTree = SOURCE_ROOT; };
 		2796C1572EEB51D800E05291 /* QuillStack.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QuillStack.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -229,6 +233,7 @@
 		E00200000000000A /* MeetingDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeetingDetailView.swift; sourceTree = "<group>"; };
 		E6CBC205145101FF179EBE6E /* TypeGuideView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TypeGuideView.swift; sourceTree = "<group>"; };
 		E6EF8D919607450456C9B843 /* RemindersServiceProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RemindersServiceProtocol.swift; path = Protocols/RemindersServiceProtocol.swift; sourceTree = "<group>"; };
+		E9810C9B1A07EFD2C73649A6 /* ExtractedTodo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExtractedTodo.swift; path = ExtractedTodo.swift; sourceTree = "<group>"; };
 		F00200000000000B /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
 		F00200000000000C /* RemindersService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemindersService.swift; sourceTree = "<group>"; };
 		F00200000000000D /* CalendarService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalendarService.swift; sourceTree = "<group>"; };
@@ -249,6 +254,7 @@
 		F00200000000001C /* OfflineQueueService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OfflineQueueService.swift; sourceTree = "<group>"; };
 		F00200000000001D /* HandwritingLearningService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HandwritingLearningService.swift; sourceTree = "<group>"; };
 		F00200000000001E /* OCRCorrection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRCorrection.swift; sourceTree = "<group>"; };
+		F28251EDDBAFBF35904F5BA9 /* ExtractedEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExtractedEvent.swift; path = ExtractedEvent.swift; sourceTree = "<group>"; };
 		F6E21F9CA4CFBAB20368840C /* CalendarServiceProtocol.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CalendarServiceProtocol.swift; path = Protocols/CalendarServiceProtocol.swift; sourceTree = "<group>"; };
 		FC24AFC5058E41E54029CC91 /* ClassificationAnalytics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ClassificationAnalytics.swift; path = Services/ClassificationAnalytics.swift; sourceTree = "<group>"; };
 		FF994FFEA388D998DB681214 /* NetworkAvailability.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NetworkAvailability.swift; path = Services/NetworkAvailability.swift; sourceTree = "<group>"; };
@@ -405,6 +411,8 @@
 				60271B88FC8F3E46581FB9B5 /* NoteType.swift */,
 				M0020000000001AA /* ActionType.swift */,
 				M0020000000001AB /* NoteAction.swift */,
+				E9810C9B1A07EFD2C73649A6 /* ExtractedTodo.swift */,
+				F28251EDDBAFBF35904F5BA9 /* ExtractedEvent.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -474,6 +482,8 @@
 				2796C1952EEB55A300E05291 /* TodoParser.swift */,
 				7C7AB6EA84595229C2256DD5 /* Protocols */,
 				135689AE59463E16DB510DA6 /* DetailViewFactory.swift */,
+				445B55CF33378CD07282DDBC /* Extraction */,
+				05C42B046C56E7232F89EB98 /* DateParsingService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -569,6 +579,14 @@
 				56803BCB82A6429F15287083 /* Models */,
 			);
 			name = QuillStack;
+			sourceTree = "<group>";
+		};
+		445B55CF33378CD07282DDBC /* Extraction */ = {
+			isa = PBXGroup;
+			children = (
+				0E371EA26DD1A11EEF03D8A3 /* EventExtractor.swift */,
+			);
+			name = Extraction;
 			sourceTree = "<group>";
 		};
 		56803BCB82A6429F15287083 /* Models */ = {
@@ -1051,9 +1069,11 @@
 				E539285A06F9FCBB990395A3 /* LLMRateLimiter.swift in Sources */,
 				76196027B23F99473691C734 /* LLMCostTracker.swift in Sources */,
 				546F2F8E7516FB2AB0B1A1EF /* NoteClassification.swift in Sources */,
-				3BE2C1EC12DEBD683AF11821 /* ClassificationBadge.swift in Sources */,
-				3EDE6B3B9044C334344F6EF6 /* NoteTypePickerSheet.swift in Sources */,
 				913ADB2ED128AEA3957A143B /* ClassificationAnalytics.swift in Sources */,
+				AA8C277426330FD77BF879DC /* ExtractedTodo.swift in Sources */,
+				A00952A62E5A5F4244EC6F42 /* ExtractedEvent.swift in Sources */,
+				0E8B9EEBC4BEFD11CAD58716 /* DateParsingService.swift in Sources */,
+				3F0F7AED3A70BDE27E9F49A9 /* EventExtractor.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
### **User description**
Fixes compilation errors reported in workspace.

## Problem
Build errors:
```
Cannot find 'TodoExtractionJSON' in scope
Cannot find type 'ExtractedTodo' in scope
```

## Root Cause
Files created in PR #19 and #20 existed on disk but were never added to the Xcode project target membership. Xcode couldn't compile them.

## Solution
Added to QuillStack target:
- ✅ Models/ExtractedTodo.swift
- ✅ Models/ExtractedEvent.swift
- ✅ Services/Extraction/EventExtractor.swift
- ✅ Services/DateParsingService.swift

## Verification
Build now succeeds:
```
** BUILD SUCCEEDED **
```

Fixes scope errors in TodoParser.swift and enables EventExtractor functionality.


___

### **PR Type**
Bug fix


___

### **Description**
- Added four missing files to Xcode project target membership

- Resolves 'Cannot find in scope' compilation errors for ExtractedTodo and ExtractedEvent

- Enables EventExtractor and DateParsingService functionality in build

- Removes duplicate build file references that caused conflicts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Files on Disk"] -->|"Not in Target"| B["Build Errors"]
  B -->|"Add to PBXBuildFile"| C["Xcode Project"]
  C -->|"Add to PBXFileReference"| D["Build Succeeds"]
  E["ExtractedTodo.swift"] -->|"Added"| C
  F["ExtractedEvent.swift"] -->|"Added"| C
  G["EventExtractor.swift"] -->|"Added"| C
  H["DateParsingService.swift"] -->|"Added"| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project.pbxproj</strong><dd><code>Register missing source files in Xcode project</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

QuillStack.xcodeproj/project.pbxproj

<ul><li>Added four PBXBuildFile entries for ExtractedTodo.swift, <br>ExtractedEvent.swift, EventExtractor.swift, and <br>DateParsingService.swift<br> <li> Added corresponding PBXFileReference entries with proper file paths <br>and source tree settings<br> <li> Created new Extraction group under Services to organize <br>EventExtractor.swift<br> <li> Added ExtractedTodo.swift and ExtractedEvent.swift to Models group<br> <li> Removed duplicate build file references for ClassificationBadge.swift <br>and NoteTypePickerSheet.swift that were causing conflicts<br> <li> Updated Sources build phase to include all four newly added files</ul>


</details>


  </td>
  <td><a href="https://github.com/mikemott/QuillStack/pull/24/files#diff-66fc8209964f5b489eaa319394434dca62d171e8670c4d5fa6697a70e441fb10">+24/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

