### PR TITLE
Fix build verification to actually fail on build errors

### DIFF
--- a/.github/workflows/verify-xcode-project.yml
+++ b/.github/workflows/verify-xcode-project.yml
@@ -46,4 +46,15 @@ jobs:
       - name: Verify project builds
         run: |
           echo "🔨 Verifying project builds..."
-          xcodebuild -project QuillStack.xcodeproj -scheme QuillStack -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' build | grep -E "(error:|BUILD SUCCEEDED)" || true
+          set -o pipefail
+
+          # Run build and capture output
+          if xcodebuild -project QuillStack.xcodeproj -scheme QuillStack -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2' build 2>&1 | tee build.log; then
+            echo "✅ Build succeeded"
+          else
+            echo "❌ Build failed"
+            echo ""
+            echo "Errors:"
+            grep -E "error:" build.log || echo "No specific errors found in log"
+            exit 1
+          fi


### PR DESCRIPTION
### **User description**
Addresses PR-Agent feedback from PR #25: build failures were being masked.

## Problem

The build verification step had a critical flaw:
```bash
xcodebuild ... | grep -E "(error:|BUILD SUCCEEDED)" || true
```

This meant:
- ❌ Piping to `grep` lost xcodebuild's exit code
- ❌ `|| true` made the command always succeed
- ❌ **Build failures never failed CI checks**
- ❌ The verification step was useless

## Solution

```bash
set -o pipefail

if xcodebuild ... 2>&1 | tee build.log; then
  echo "✅ Build succeeded"
else
  echo "❌ Build failed"
  grep -E "error:" build.log
  exit 1
fi
```

Now:
- ✅ `set -o pipefail` propagates exit codes through pipes
- ✅ `tee` captures output while preserving exit code
- ✅ `if` checks actual xcodebuild exit code
- ✅ `exit 1` fails the CI check on build failure
- ✅ Shows specific errors from build log

## Impact

Build verification will now **actually work** - CI checks will fail if the project doesn't build, preventing broken code from being merged.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix build verification to properly fail on build errors

- Replace grep piping with pipefail and tee for exit code preservation

- Add explicit error handling and detailed error output

- Ensure CI checks fail when project build fails


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old: xcodebuild pipe grep"] -->|"loses exit code"| B["Always succeeds"]
  C["New: set pipefail + tee"] -->|"preserves exit code"| D["if statement checks result"]
  D -->|"success"| E["✅ Build succeeded"]
  D -->|"failure"| F["❌ Build failed + exit 1"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>verify-xcode-project.yml</strong><dd><code>Fix build verification exit code handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/verify-xcode-project.yml

<ul><li>Added <code>set -o pipefail</code> to propagate exit codes through pipes<br> <li> Replaced grep piping with <code>tee</code> to capture output while preserving <br>xcodebuild exit code<br> <li> Wrapped build command in if/else statement to check actual exit status<br> <li> Added explicit error handling with detailed error output and <code>exit 1</code> on <br>failure<br> <li> Improved error reporting by grepping build.log for specific errors</ul>


</details>


  </td>
  <td><a href="https://github.com/mikemott/QuillStack/pull/26/files#diff-0dd328f53a0da6466344a87a28705ff75a62dba914494e96bf76579de05a6f8f">+12/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

