### PR TITLE
QUI-127: Share DateParsingService between todo extraction modules

### DIFF
--- a/Services/MeetingParser.swift
+++ b/Services/MeetingParser.swift
@@ -221,26 +221,7 @@ class MeetingParser {
     }
 
     private func parseDateString(_ string: String) -> Date? {
-        let formatter = DateFormatter()
-
-        // Try MM/dd/yyyy format
-        formatter.dateFormat = "MM/dd/yyyy"
-        if let date = formatter.date(from: string) {
-            return date
-        }
-
-        // Try MM/dd/yy format
-        formatter.dateFormat = "MM/dd/yy"
-        if let date = formatter.date(from: string) {
-            return date
-        }
-
-        // Try full text format
-        formatter.dateFormat = "MMMM dd, yyyy"
-        if let date = formatter.date(from: string) {
-            return date
-        }
-
-        return nil
+        // Use shared DateParsingService for robust date parsing
+        return DateParsingService.parse(dateString: string)
     }
 }

--- a/Services/TodoParser.swift
+++ b/Services/TodoParser.swift
@@ -254,26 +254,7 @@ class TodoParser {
     }
 
     private func parseDateString(_ string: String) -> Date? {
-        let formatter = DateFormatter()
-
-        // Try MM/dd/yy format
-        formatter.dateFormat = "MM/dd/yy"
-        if let date = formatter.date(from: string) {
-            return date
-        }
-
-        // Try MM/dd/yyyy format
-        formatter.dateFormat = "MM/dd/yyyy"
-        if let date = formatter.date(from: string) {
-            return date
-        }
-
-        // Try MM/dd format (current year)
-        formatter.dateFormat = "MM/dd"
-        if let date = formatter.date(from: string) {
-            return date
-        }
-
-        return nil
+        // Use shared DateParsingService for robust date parsing
+        return DateParsingService.parse(dateString: string)
     }
 }


### PR DESCRIPTION
### **User description**
Closes QUI-127

## Summary
Consolidates duplicate date parsing logic from TodoParser and MeetingParser into the centralized DateParsingService. This removes ~45 lines of duplicate code and ensures consistent date parsing behavior across the app.

## Changes
- **TodoParser.swift**: Replaced custom `parseDateString` method with `DateParsingService.parse()`
- **MeetingParser.swift**: Replaced custom `parseDateString` method with `DateParsingService.parse()`

## Benefits
- **Single source of truth**: All date parsing now goes through DateParsingService
- **More robust parsing**: Inherits NSDataDetector capabilities and natural language support
- **Easier maintenance**: Changes to date parsing logic only need to be made in one place

## Testing
- ✅ Build succeeded with no errors
- ✅ All existing date parsing functionality preserved


___

### **PR Type**
Enhancement


___

### **Description**
- Consolidates duplicate date parsing logic into centralized DateParsingService

- Removes ~45 lines of duplicate code from TodoParser and MeetingParser

- Ensures consistent date parsing behavior across extraction modules

- Improves maintainability with single source of truth for date parsing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  TP["TodoParser.swift"]
  MP["MeetingParser.swift"]
  DPS["DateParsingService"]
  TP -- "uses" --> DPS
  MP -- "uses" --> DPS
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TodoParser.swift</strong><dd><code>Replace custom date parsing with shared service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Services/TodoParser.swift

<ul><li>Removed custom <code>parseDateString</code> method with three DateFormatter <br>attempts<br> <li> Replaced with call to <code>DateParsingService.parse(dateString:)</code><br> <li> Eliminates duplicate date parsing logic for MM/dd/yy, MM/dd/yyyy, and <br>MM/dd formats</ul>


</details>


  </td>
  <td><a href="https://github.com/mikemott/QuillStack/pull/30/files#diff-c40413d57e979bfd0a16ba485db4f40d7794a67d602ec89754296b941bc77909">+2/-21</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MeetingParser.swift</strong><dd><code>Replace custom date parsing with shared service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Services/MeetingParser.swift

<ul><li>Removed custom <code>parseDateString</code> method with three DateFormatter <br>attempts<br> <li> Replaced with call to <code>DateParsingService.parse(dateString:)</code><br> <li> Eliminates duplicate date parsing logic for MM/dd/yyyy, MM/dd/yy, and <br>MMMM dd, yyyy formats</ul>


</details>


  </td>
  <td><a href="https://github.com/mikemott/QuillStack/pull/30/files#diff-11aa3bf4adca0540589066a6cd28f9309f6411190933fddd773fc90ef38b5645">+2/-21</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

