### PR TITLE
App hang performance issue

### DIFF
--- a/App/QuillStackApp.swift
+++ b/App/QuillStackApp.swift
@@ -54,6 +54,9 @@ struct QuillStackApp: App {
 
         // Register all built-in note type plugins
         NoteTypeRegistry.shared.registerBuiltInPlugins()
+
+        // Warm up expensive services (OCR/ImageProcessor) off the main thread to prevent launch hangs
+        ServicePrewarmer.warmHeavyServices()
     }
 
     var body: some Scene {

--- a/Services/ImageProcessor.swift
+++ b/Services/ImageProcessor.swift
@@ -9,8 +9,19 @@ import UIKit
 import CoreImage
 import Vision
 
-class ImageProcessor {
-    private let context = CIContext(options: [.useSoftwareRenderer: false])
+final class ImageProcessor {
+    static let shared = ImageProcessor()
+
+    private lazy var context: CIContext = {
+        CIContext(options: [.useSoftwareRenderer: false])
+    }()
+
+    private init() {}
+
+    /// Preloads expensive GPU resources on a background queue
+    func warmUp() {
+        _ = context
+    }
 
     /// Preprocesses image for better OCR accuracy
     func preprocess(image: UIImage) -> UIImage? {

--- a/Services/OCRService.swift
+++ b/Services/OCRService.swift
@@ -85,7 +85,7 @@ final class OCRService: OCRServiceProtocol, @unchecked Sendable {
         case invalidImage
     }
 
-    private let imageProcessor = ImageProcessor()
+    private let imageProcessor = ImageProcessor.shared
 
     // Common words in emails and handwritten notes to improve recognition
     private nonisolated let customVocabulary = [

--- a/Services/ServicePrewarmer.swift
+++ b/Services/ServicePrewarmer.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum ServicePrewarmer {
+    private static var hasStartedWarmup = false
+
+    static func warmHeavyServices() {
+        guard !hasStartedWarmup else { return }
+        hasStartedWarmup = true
+
+        Task.detached(priority: .utility) {
+            // Force expensive GPU contexts and OCR singletons to initialize off the main thread
+            ImageProcessor.shared.warmUp()
+            _ = OCRService.shared
+        }
+    }
+}

--- a/ViewModels/CameraViewModel.swift
+++ b/ViewModels/CameraViewModel.swift
@@ -22,7 +22,7 @@ final class CameraViewModel {
     // Dependencies (protocol-based for testability)
     private let ocrService: OCRServiceProtocol
     private let textClassifier: TextClassifierProtocol
-    private let imageProcessor = ImageProcessor()
+    private let imageProcessor = ImageProcessor.shared
     private let spellCorrector = SpellCorrector()
     private let settings = SettingsManager.shared
 


### PR DESCRIPTION
Preload OCR and ImageProcessor services on a background thread to prevent app launch hangs.

The app was experiencing 2-3 second hangs during launch due to Core Image spinning up on the main thread when `ImageProcessor` or `OCRService` were first accessed. This change initializes these expensive services on a detached task, keeping the main thread free.

---
Linear Issue: [QUI-130](https://linear.app/quillstack/issue/QUI-130/app-hang-fully-blocked-app-hanging-between-24-and-32-seconds)

<a href="https://cursor.com/background-agent?bcId=bc-ed046ee2-a85d-49e9-ad23-1e1948335bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ed046ee2-a85d-49e9-ad23-1e1948335bb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

