### PR TITLE
fix(QUILLSTACK-44/45): threading fixes, Chandra 2 model, iCloud backup

### DIFF
--- a/QuillStack.xcodeproj/project.pbxproj
+++ b/QuillStack.xcodeproj/project.pbxproj
@@ -102,7 +102,8 @@
 		78DF9BEE4F2F7F4D360A6506 /* EventActionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventActionView.swift; sourceTree = "<group>"; };
 		7BDD1012BB13C6FEEFD5AD9A /* CaptureImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureImage.swift; sourceTree = "<group>"; };
 		7DED94D89E0E9CD89DA0CDB8 /* PromptBuilderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptBuilderTests.swift; sourceTree = "<group>"; };
-		817E6AAE6434F0F869ED3954 /* QuillStack.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = QuillStack.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		817E6AAE6434F0F869ED3954 /* QuillStack.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = QuillStack.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		82554B68A8D4B7351B5E70C9 /* QuillStack.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = QuillStack.entitlements; sourceTree = "<group>"; };
 		830DBB50D82C00865610C70E /* ActionIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionIcon.swift; sourceTree = "<group>"; };
 		84704540B805D88979BF52CD /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		9C8847CCF72D440E5D1258E3 /* CaptureDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureDetailView.swift; sourceTree = "<group>"; };
@@ -240,6 +241,7 @@
 			isa = PBXGroup;
 			children = (
 				3FB76058408D13419B7BE321 /* Assets.xcassets */,
+				82554B68A8D4B7351B5E70C9 /* QuillStack.entitlements */,
 				1259D777AD7D35451FCEDC2A /* App */,
 				E846F93AD9E4D1ECB67861D1 /* Models */,
 				3EECED0CADFB246418452A4C /* Resources */,
@@ -551,8 +553,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				CODE_SIGN_ENTITLEMENTS = QuillStack/QuillStack.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = HZQB6JS358;
 				DWARF_DSYM_FILE_SHOULD_ACCOMPANY_PRODUCT = NO;
 				INFOPLIST_FILE = QuillStack/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -710,8 +714,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
+				CODE_SIGN_ENTITLEMENTS = QuillStack/QuillStack.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = HZQB6JS358;
 				DWARF_DSYM_FILE_SHOULD_ACCOMPANY_PRODUCT = NO;
 				INFOPLIST_FILE = QuillStack/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/QuillStack/App/QuillStackApp.swift
+++ b/QuillStack/App/QuillStackApp.swift
@@ -18,13 +18,31 @@ struct QuillStackApp: App {
         }
         let schema = Schema([Capture.self, CaptureImage.self, Tag.self, PendingOCRRequest.self])
         let inMemory = Self.isUITesting
-        let config = ModelConfiguration("QuillStack", isStoredInMemoryOnly: inMemory)
+        let useCloud = !inMemory && FileManager.default.ubiquityIdentityToken != nil
+
+        let config = ModelConfiguration(
+            "QuillStack",
+            isStoredInMemoryOnly: inMemory,
+            cloudKitDatabase: useCloud ? .automatic : .none
+        )
         do {
             container = try ModelContainer(for: schema, configurations: [config])
         } catch {
-            fatalError("Failed to create ModelContainer: \(error)")
+            // CloudKit setup can fail even with an iCloud account (e.g. container
+            // not yet provisioned). Fall back to local-only storage.
+            let fallback = ModelConfiguration(
+                "QuillStack",
+                isStoredInMemoryOnly: inMemory,
+                cloudKitDatabase: .none
+            )
+            do {
+                container = try ModelContainer(for: schema, configurations: [fallback])
+            } catch {
+                fatalError("Failed to create ModelContainer: \(error)")
+            }
         }
         seedDefaultTags(in: container)
+        deduplicateTags(in: container.mainContext)
         if !Self.isUITesting {
             configureMacMini()
             registerBackgroundTask()
@@ -32,6 +50,11 @@ struct QuillStackApp: App {
     }
 
     private func configureMacMini() {
+        // Migrate stale Qwen model name to Chandra 2
+        if UserDefaults.standard.string(forKey: "ollamaModel") == "qwen3-vl:8b" {
+            UserDefaults.standard.set("chandra-ocr-2", forKey: "ollamaModel")
+        }
+
         Task {
             if let savedHost = UserDefaults.standard.string(forKey: "macMiniHost") {
                 await RemoteOCRService.shared.setMacMiniHost(savedHost)
@@ -53,6 +76,7 @@ struct QuillStackApp: App {
         .onChange(of: scenePhase) { _, newPhase in
             switch newPhase {
             case .active:
+                deduplicateTags(in: container.mainContext)
                 Task {
                     await OCRQueueService.shared.processQueue(in: container.mainContext)
                 }
@@ -120,6 +144,30 @@ struct QuillStackApp: App {
             task.setTaskCompleted(success: true)
             scheduleBackgroundProcessing()
         }
+    }
+
+    // MARK: - Tag Deduplication
+
+    private func deduplicateTags(in context: ModelContext) {
+        let descriptor = FetchDescriptor<Tag>(sortBy: [SortDescriptor(\.createdAt)])
+        guard let tags = try? context.fetch(descriptor) else { return }
+
+        var seen: [String: Tag] = [:]
+        for tag in tags {
+            let key = tag.name.lowercased()
+            if let existing = seen[key] {
+                // Move captures from duplicate to the original
+                for capture in tag.captures {
+                    if !existing.captures.contains(where: { $0.id == capture.id }) {
+                        existing.captures.append(capture)
+                    }
+                }
+                context.delete(tag)
+            } else {
+                seen[key] = tag
+            }
+        }
+        try? context.save()
     }
 
     // MARK: - Seed Tags

--- a/QuillStack/App/QuillStackApp.swift
+++ b/QuillStack/App/QuillStackApp.swift
@@ -157,10 +157,8 @@ struct QuillStackApp: App {
             let key = tag.name.lowercased()
             if let existing = seen[key] {
                 // Move captures from duplicate to the original
-                for capture in tag.captures {
-                    if !existing.captures.contains(where: { $0.id == capture.id }) {
-                        existing.captures.append(capture)
-                    }
+                for capture in tag.captures where !existing.captures.contains(where: { $0.id == capture.id }) {
+                    existing.captures.append(capture)
                 }
                 context.delete(tag)
             } else {

--- a/QuillStack/App/QuillStackApp.swift
+++ b/QuillStack/App/QuillStackApp.swift
@@ -157,7 +157,10 @@ struct QuillStackApp: App {
             let key = tag.name.lowercased()
             if let existing = seen[key] {
                 // Move captures from duplicate to the original
-                for capture in tag.captures where !existing.captures.contains(where: { $0.id == capture.id }) {
+                let capturesToMove = tag.captures.filter { capture in
+                    !existing.captures.contains(where: { $0.id == capture.id })
+                }
+                for capture in capturesToMove {
                     existing.captures.append(capture)
                 }
                 context.delete(tag)

--- a/QuillStack/App/QuillStackApp.swift
+++ b/QuillStack/App/QuillStackApp.swift
@@ -18,7 +18,7 @@ struct QuillStackApp: App {
         }
         let schema = Schema([Capture.self, CaptureImage.self, Tag.self, PendingOCRRequest.self])
         let inMemory = Self.isUITesting
-        let useCloud = !inMemory && FileManager.default.ubiquityIdentityToken != nil
+        let useCloud = !inMemory
 
         let config = ModelConfiguration(
             "QuillStack",

--- a/QuillStack/Models/Capture.swift
+++ b/QuillStack/Models/Capture.swift
@@ -4,13 +4,13 @@ import CoreLocation
 
 @Model
 final class Capture {
-    var createdAt: Date
+    var createdAt: Date = Date.now
     var extractedTitle: String?
     var ocrText: String?
     var latitude: Double?
     var longitude: Double?
     var locationName: String?
-    var isProcessingOCR: Bool
+    var isProcessingOCR: Bool = false
     var enrichmentJSON: Data?
 
     @Relationship(deleteRule: .cascade, inverse: \CaptureImage.capture)

--- a/QuillStack/Models/CaptureImage.swift
+++ b/QuillStack/Models/CaptureImage.swift
@@ -3,9 +3,9 @@ import SwiftData
 
 @Model
 final class CaptureImage {
-    @Attribute(.externalStorage) var imageData: Data
+    @Attribute(.externalStorage) var imageData: Data = Data()
     @Attribute(.externalStorage) var thumbnailData: Data?
-    var pageIndex: Int
+    var pageIndex: Int = 0
     var ocrText: String?
     var ocrConfidence: Double?
     var capture: Capture?

--- a/QuillStack/Models/PendingOCRRequest.swift
+++ b/QuillStack/Models/PendingOCRRequest.swift
@@ -3,10 +3,10 @@ import SwiftData
 
 @Model
 final class PendingOCRRequest {
-    @Attribute(.unique) var id: UUID
-    var imageData: Data
-    var createdAt: Date
-    var retryCount: Int
+    var id: UUID = UUID()
+    var imageData: Data = Data()
+    var createdAt: Date = Date.now
+    var retryCount: Int = 0
 
     @Relationship var capture: Capture?
 

--- a/QuillStack/Models/Tag.swift
+++ b/QuillStack/Models/Tag.swift
@@ -4,10 +4,10 @@ import SwiftUI
 
 @Model
 final class Tag {
-    @Attribute(.unique) var name: String
-    var colorHex: String
-    var createdAt: Date
-    var captures: [Capture]
+    var name: String = ""
+    var colorHex: String = "#6B7280"
+    var createdAt: Date = Date.now
+    var captures: [Capture] = []
 
     init(name: String, colorHex: String) {
         self.name = name

--- a/QuillStack/QuillStack.entitlements
+++ b/QuillStack/QuillStack.entitlements
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.quillstack.app</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudDocuments</string>
+		<string>CloudKit</string>
+	</array>
+	<key>com.apple.developer.ubiquity-container-identifiers</key>
+	<array>
+		<string>iCloud.com.quillstack.app</string>
+	</array>
+</dict>
+</plist>

--- a/QuillStack/QuillStack.entitlements
+++ b/QuillStack/QuillStack.entitlements
@@ -8,12 +8,7 @@
 	</array>
 	<key>com.apple.developer.icloud-services</key>
 	<array>
-		<string>CloudDocuments</string>
 		<string>CloudKit</string>
-	</array>
-	<key>com.apple.developer.ubiquity-container-identifiers</key>
-	<array>
-		<string>iCloud.com.quillstack.app</string>
 	</array>
 </dict>
 </plist>

--- a/QuillStack/Services/CaptureProcessor.swift
+++ b/QuillStack/Services/CaptureProcessor.swift
@@ -20,7 +20,10 @@ final class CaptureProcessor {
 
         let imageData = primaryImage.imageData
 
-        Task { @MainActor in
+        // Task inherits @MainActor; await calls to RemoteOCRService (an actor)
+        // naturally hop off main thread for network work, then resume here
+        // for SwiftData mutations.
+        Task {
             do {
                 guard await remoteOCRService.checkAvailability() else {
                     logger.info("Mac Mini unavailable, queueing OCR request")

--- a/QuillStack/Services/OCRQueueService.swift
+++ b/QuillStack/Services/OCRQueueService.swift
@@ -48,7 +48,6 @@ final class OCRQueueService {
         logger.info("Processing \(requests.count) pending OCR requests")
 
         for request in requests {
-            // Check for orphaned requests before doing network work
             guard let capture = request.capture else {
                 logger.warning("Capture not found for pending request, removing from queue")
                 context.delete(request)
@@ -58,7 +57,11 @@ final class OCRQueueService {
 
             do {
                 let tagNames = Set(capture.tags.map(\.name))
-                let result = try await remoteOCR.recognizeText(from: request.imageData, tagNames: tagNames)
+                let imageData = request.imageData
+
+                let result = try await Task.detached {
+                    try await remoteOCR.recognizeText(from: imageData, tagNames: tagNames)
+                }.value
 
                 capture.ocrText = result.text
                 capture.extractedTitle = result.title

--- a/QuillStack/Services/OCRQueueService.swift
+++ b/QuillStack/Services/OCRQueueService.swift
@@ -13,7 +13,7 @@ final class OCRQueueService {
     private init() {}
 
     func enqueue(capture: Capture, imageData: Data, in context: ModelContext) throws {
-        let allPending = (try? context.fetch(FetchDescriptor<PendingOCRRequest>())) ?? []
+        let allPending = try context.fetch(FetchDescriptor<PendingOCRRequest>())
         if allPending.contains(where: { $0.capture?.persistentModelID == capture.persistentModelID }) {
             logger.debug("OCR request already queued for this capture, skipping")
             return

--- a/QuillStack/Services/OCRQueueService.swift
+++ b/QuillStack/Services/OCRQueueService.swift
@@ -13,6 +13,12 @@ final class OCRQueueService {
     private init() {}
 
     func enqueue(capture: Capture, imageData: Data, in context: ModelContext) throws {
+        let allPending = (try? context.fetch(FetchDescriptor<PendingOCRRequest>())) ?? []
+        if allPending.contains(where: { $0.capture?.persistentModelID == capture.persistentModelID }) {
+            logger.debug("OCR request already queued for this capture, skipping")
+            return
+        }
+
         let request = PendingOCRRequest(capture: capture, imageData: imageData)
         context.insert(request)
         try context.save()
@@ -59,9 +65,7 @@ final class OCRQueueService {
                 let tagNames = Set(capture.tags.map(\.name))
                 let imageData = request.imageData
 
-                let result = try await Task.detached {
-                    try await remoteOCR.recognizeText(from: imageData, tagNames: tagNames)
-                }.value
+                let result = try await remoteOCR.recognizeText(from: imageData, tagNames: tagNames)
 
                 capture.ocrText = result.text
                 capture.extractedTitle = result.title

--- a/QuillStack/Services/RemoteOCRService.swift
+++ b/QuillStack/Services/RemoteOCRService.swift
@@ -138,11 +138,20 @@ actor RemoteOCRService {
         var parsed: [String: Any]?
         for candidate in [responseText, thinkingText] {
             guard let candidate, !candidate.isEmpty else { continue }
-            // Strip markdown code fences if present
-            let cleaned = candidate
-                .replacingOccurrences(of: "```json", with: "")
-                .replacingOccurrences(of: "```", with: "")
-                .trimmingCharacters(in: .whitespacesAndNewlines)
+            // Strip outer markdown code fences if present
+            let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+            let cleaned: String
+            if trimmed.hasPrefix("```") && trimmed.hasSuffix("```") {
+                cleaned = trimmed
+                    .replacingOccurrences(
+                        of: #"^```(?:json)?\s*|\s*```$"#,
+                        with: "",
+                        options: .regularExpression
+                    )
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            } else {
+                cleaned = trimmed
+            }
             guard let candidateData = cleaned.data(using: .utf8),
                   let obj = try? JSONSerialization.jsonObject(with: candidateData) as? [String: Any] else {
                 continue

--- a/QuillStack/Services/RemoteOCRService.swift
+++ b/QuillStack/Services/RemoteOCRService.swift
@@ -10,7 +10,7 @@ actor RemoteOCRService {
     private var modelName: String
     private var modelPreloaded = false
 
-    init(macMiniHost: String = "", modelName: String = "qwen3-vl:8b") {
+    init(macMiniHost: String = "", modelName: String = "chandra-ocr-2") {
         self.macMiniHost = macMiniHost
         self.modelName = modelName
     }
@@ -134,11 +134,16 @@ actor RemoteOCRService {
         let responseText = json?["response"] as? String
         let thinkingText = json?["thinking"] as? String
 
-        // Parse structured JSON from response or thinking field (Qwen3 thinking mode)
+        // Parse structured JSON from response
         var parsed: [String: Any]?
         for candidate in [responseText, thinkingText] {
-            guard let candidate, !candidate.isEmpty,
-                  let candidateData = candidate.data(using: .utf8),
+            guard let candidate, !candidate.isEmpty else { continue }
+            // Strip markdown code fences if present
+            let cleaned = candidate
+                .replacingOccurrences(of: "```json", with: "")
+                .replacingOccurrences(of: "```", with: "")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let candidateData = cleaned.data(using: .utf8),
                   let obj = try? JSONSerialization.jsonObject(with: candidateData) as? [String: Any] else {
                 continue
             }

--- a/QuillStack/Views/Capture/CaptureFlowView.swift
+++ b/QuillStack/Views/Capture/CaptureFlowView.swift
@@ -130,14 +130,13 @@ struct CaptureFlowView: View {
         let processor = CaptureProcessor()
         processor.process(capture, in: modelContext)
 
-        // Location in background
-        let ctx = modelContext
-        Task {
+        // Location in background — stay on MainActor for SwiftData access
+        Task { @MainActor in
             if let location = await locationService.currentLocation() {
                 capture.latitude = location.coordinate.latitude
                 capture.longitude = location.coordinate.longitude
                 capture.locationName = await locationService.reverseGeocode(location)
-                try? ctx.save()
+                try? modelContext.save()
             }
         }
 

--- a/QuillStack/Views/Settings/SettingsView.swift
+++ b/QuillStack/Views/Settings/SettingsView.swift
@@ -10,11 +10,12 @@ struct SettingsView: View {
     @State private var newTagColor = "#6B7280"
     @State private var showResetConfirm = false
     @State private var macMiniHost = UserDefaults.standard.string(forKey: "macMiniHost") ?? ""
-    @State private var ollamaModel = UserDefaults.standard.string(forKey: "ollamaModel") ?? "qwen3-vl:8b"
+    @State private var ollamaModel = UserDefaults.standard.string(forKey: "ollamaModel") ?? "chandra-ocr-2"
     @State private var isConnected = false
     @State private var isCheckingConnection = false
     @State private var pendingCount = 0
     @State private var connectionCheckTask: Task<Void, Never>?
+    @State private var icloudAvailable = FileManager.default.ubiquityIdentityToken != nil
     @State private var vaultPath = UserDefaults.standard.string(forKey: "obsidianVaultPath") ?? ""
     @State private var attachmentFolder = UserDefaults.standard.string(forKey: "obsidianAttachmentFolder") ?? "attachments"
     @State private var dailyNoteFolder = UserDefaults.standard.string(forKey: "obsidianDailyNoteFolder") ?? ""
@@ -34,6 +35,7 @@ struct SettingsView: View {
                 obsidianSection
                 storageSection
                 ocrSection
+                icloudSection
                 aboutSection
             }
             .padding(.horizontal, 20)
@@ -45,6 +47,7 @@ struct SettingsView: View {
         .task {
             await checkConnection()
             pendingCount = OCRQueueService.shared.getPendingCount(in: modelContext)
+            icloudAvailable = FileManager.default.ubiquityIdentityToken != nil
         }
         .alert("New Tag", isPresented: $showNewTag) {
             TextField("Tag name", text: $newTagName)
@@ -269,6 +272,41 @@ struct SettingsView: View {
             }
 
             Text("Enter your Mac Mini's Tailscale IP address. Captures queue when offline.")
+                .font(QSFont.monoLight(size: 11))
+                .foregroundStyle(QSColor.onSurfaceMuted)
+                .padding(.leading, 4)
+        }
+    }
+
+    // MARK: - iCloud
+
+    private var icloudSection: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            sectionHeader("ICLOUD BACKUP")
+
+            VStack(spacing: 0) {
+                settingsRow("Status") {
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(icloudAvailable ? Color.green : QSColor.onSurfaceMuted)
+                            .frame(width: 8, height: 8)
+                            .opacity(icloudAvailable ? 1.0 : 0.3)
+                        Text(icloudAvailable ? "Active" : "Unavailable")
+                            .font(QSFont.mono(size: 13))
+                            .foregroundStyle(QSColor.onSurfaceMuted)
+                    }
+                }
+
+                settingsRow("Account") {
+                    Text(icloudAvailable ? "Signed In" : "Not Signed In")
+                        .font(QSFont.mono(size: 13))
+                        .foregroundStyle(QSColor.onSurfaceMuted)
+                }
+            }
+            .background(QSSurface.container)
+            .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+            Text("Captures and tags sync to iCloud automatically. Data restores when you reinstall.")
                 .font(QSFont.monoLight(size: 11))
                 .foregroundStyle(QSColor.onSurfaceMuted)
                 .padding(.leading, 4)

--- a/QuillStack/Views/Settings/SettingsView.swift
+++ b/QuillStack/Views/Settings/SettingsView.swift
@@ -288,7 +288,7 @@ struct SettingsView: View {
                 settingsRow("Status") {
                     HStack(spacing: 6) {
                         Circle()
-                            .fill(icloudAvailable ? Color.green : QSColor.onSurfaceMuted)
+                            .fill(QSColor.onSurfaceMuted)
                             .frame(width: 8, height: 8)
                             .opacity(icloudAvailable ? 1.0 : 0.3)
                         Text(icloudAvailable ? "Active" : "Unavailable")

--- a/QuillStack/Views/Settings/SettingsView.swift
+++ b/QuillStack/Views/Settings/SettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SwiftData
+import CloudKit
 
 struct SettingsView: View {
     @Environment(\.modelContext) private var modelContext
@@ -15,7 +16,7 @@ struct SettingsView: View {
     @State private var isCheckingConnection = false
     @State private var pendingCount = 0
     @State private var connectionCheckTask: Task<Void, Never>?
-    @State private var icloudAvailable = FileManager.default.ubiquityIdentityToken != nil
+    @State private var icloudAvailable = false
     @State private var vaultPath = UserDefaults.standard.string(forKey: "obsidianVaultPath") ?? ""
     @State private var attachmentFolder = UserDefaults.standard.string(forKey: "obsidianAttachmentFolder") ?? "attachments"
     @State private var dailyNoteFolder = UserDefaults.standard.string(forKey: "obsidianDailyNoteFolder") ?? ""
@@ -47,7 +48,8 @@ struct SettingsView: View {
         .task {
             await checkConnection()
             pendingCount = OCRQueueService.shared.getPendingCount(in: modelContext)
-            icloudAvailable = FileManager.default.ubiquityIdentityToken != nil
+            let status = try? await CKContainer.default().accountStatus()
+            icloudAvailable = status == .available
         }
         .alert("New Tag", isPresented: $showNewTag) {
             TextField("Tag name", text: $newTagName)

--- a/project.yml
+++ b/project.yml
@@ -31,6 +31,7 @@ targets:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS: YES
         DWARF_DSYM_FILE_SHOULD_ACCOMPANY_PRODUCT: NO
+        CODE_SIGN_ENTITLEMENTS: QuillStack/QuillStack.entitlements
     preBuildScripts:
       - script: |
           if command -v swiftlint >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- **Fix QUILLSTACK-44 crash**: Remove redundant `@MainActor` Task nesting in `CaptureProcessor` — `RemoteOCRService` is an actor, so `await` calls naturally hop off main thread while SwiftData mutations stay on `@MainActor`. Fix unsafe `modelContext` capture in `CaptureFlowView` location task.
- **Update OCR model to Chandra 2**: Default model name changed from `qwen3-vl:8b` to `chandra-ocr-2`, with one-time UserDefaults migration and markdown code fence stripping in response parser.
- **Add iCloud backup (QUILLSTACK-45)**: CloudKit sync for Captures, Images, and Tags with graceful fallback when iCloud is unavailable. Removed `@Attribute(.unique)` for CloudKit compatibility, added property defaults, tag deduplication, and sync status in Settings.

Closes QUILLSTACK-44
Closes QUILLSTACK-45

## Test plan

- [x] Build succeeds (clean)
- [x] 67 unit tests pass
- [x] 10 UI tests pass
- [ ] Verify app launches without crash on device (no more EXC_BREAKPOINT)
- [ ] Verify Settings shows correct model name (chandra-ocr-2) and connection status
- [ ] Verify iCloud Backup section appears in Settings
- [ ] Capture an image and confirm OCR processes without main-thread assertion
- [ ] Delete and reinstall app — verify data restores from iCloud (requires CloudKit container provisioned in developer portal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * iCloud/CloudKit support added with Settings showing account status and availability.
  * Automatic tag deduplication runs on startup and when returning to the app.

* **Bug Fixes**
  * More robust OCR parsing and resilience.
  * Fallback to local datastore if cloud-backed initialization fails.
  * Prevent duplicate queued OCR requests for the same capture.

* **Chores**
  * Updated default OCR model and app signing/entitlements for iCloud/CloudKit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->