### PR TITLE
feat: empty state guide and tag selection indicator

### DIFF
--- a/QuillStack/App/ContentView.swift
+++ b/QuillStack/App/ContentView.swift
@@ -139,7 +139,9 @@ struct ContentView: View {
                     // Tag filter
                     tagFilterBar
 
-                    if isDrawerMode {
+                    if captures.isEmpty {
+                        emptyStateView
+                    } else if isDrawerMode {
                         drawerView
                             .transition(.opacity)
                     } else {
@@ -215,6 +217,57 @@ struct ContentView: View {
         }
         .background(QSSurface.containerLow)
         .accessibilityIdentifier("tag-filter-bar")
+    }
+
+    // MARK: - Empty State
+
+    private var emptyStateView: some View {
+        VStack(spacing: 24) {
+            Spacer()
+
+            VStack(spacing: 16) {
+                Text("Point your phone\nat something.")
+                    .font(.system(size: 28, weight: .black))
+                    .multilineTextAlignment(.center)
+                    .foregroundStyle(QSColor.onSurface)
+
+                Text("Something happens.")
+                    .font(.system(size: 28, weight: .black))
+                    .foregroundStyle(QSColor.onSurfaceVariant)
+            }
+
+            Text("Receipts, flyers, notes, business cards —\nQuillStack reads it, tags it, does something with it.")
+                .font(QSFont.sans(size: 15))
+                .multilineTextAlignment(.center)
+                .foregroundStyle(QSColor.onSurfaceMuted)
+                .lineSpacing(4)
+                .padding(.horizontal, 32)
+
+            VStack(alignment: .leading, spacing: 12) {
+                guideStep("1", "Tap the camera button below")
+                guideStep("2", "Scan a receipt, note, or card")
+                guideStep("3", "Tag it — OCR and actions happen automatically")
+            }
+            .padding(.top, 8)
+
+            Spacer()
+            Spacer()
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private func guideStep(_ number: String, _ text: String) -> some View {
+        HStack(spacing: 12) {
+            Text(number)
+                .font(QSFont.mono(size: 12))
+                .foregroundStyle(QSColor.onSurfaceMuted)
+                .frame(width: 24, height: 24)
+                .background(QSSurface.container)
+                .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
+            Text(text)
+                .font(QSFont.sans(size: 14))
+                .foregroundStyle(QSColor.onSurfaceVariant)
+        }
     }
 
     // MARK: - Card Pager

--- a/QuillStack/Views/Capture/CaptureFlowView.swift
+++ b/QuillStack/Views/Capture/CaptureFlowView.swift
@@ -58,6 +58,22 @@ struct CaptureFlowView: View {
                     }
                 }
 
+                // Selected tags confirmation
+                if !selectedTags.isEmpty {
+                    HStack(spacing: 8) {
+                        ForEach(selectedTags) { tag in
+                            TagChip(tag: tag, size: .compact) {
+                                toggleTag(tag)
+                            }
+                        }
+                        Spacer()
+                        Text("\(selectedTags.count) tagged")
+                            .font(QSFont.mono(size: 11))
+                            .foregroundStyle(QSColor.onSurfaceMuted)
+                    }
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                }
+
                 Button {
                     finishCapture(capture)
                 } label: {

--- a/QuillStack/Views/Capture/CaptureFlowView.swift
+++ b/QuillStack/Views/Capture/CaptureFlowView.swift
@@ -61,15 +61,20 @@ struct CaptureFlowView: View {
                 // Selected tags confirmation
                 if !selectedTags.isEmpty {
                     HStack(spacing: 8) {
-                        ForEach(selectedTags) { tag in
-                            TagChip(tag: tag, size: .compact) {
-                                toggleTag(tag)
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 8) {
+                                ForEach(selectedTags) { tag in
+                                    TagChip(tag: tag, size: .compact) {
+                                        toggleTag(tag)
+                                    }
+                                    .accessibilityIdentifier("selected-tag-\(tag.name)")
+                                }
                             }
                         }
-                        Spacer()
                         Text("\(selectedTags.count) tagged")
                             .font(QSFont.mono(size: 11))
                             .foregroundStyle(QSColor.onSurfaceMuted)
+                            .fixedSize()
                     }
                     .transition(.move(edge: .bottom).combined(with: .opacity))
                 }


### PR DESCRIPTION
## Summary

- **Empty state**: When no captures exist, shows the marketing tagline ("Point your phone at something. Something happens.") with a brief 3-step onboarding guide. Matches the website's typographic style.
- **Tag selection indicator**: Compact colored TagChip row appears between the tag grid and DONE button during capture flow, showing which tags are selected with a count. Chips are tappable to deselect.

## Test plan

- [x] Build succeeds
- [x] All unit + UI tests pass
- [ ] Verify empty state appears on fresh install / after reset
- [ ] Verify tag indicator row appears when selecting tags during capture
- [ ] Verify tapping a chip in the indicator row deselects the tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Empty state screen with onboarding guidance now appears when no captures exist, guiding users through initial steps.
  * Tag picker confirmation row shows currently selected tags as visual chips with a compact count label and smooth enter/exit animations for clearer selection feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->