### PR TITLE
Empty state: informative first-run copy

### DIFF
--- a/QuillStack/App/ContentView.swift
+++ b/QuillStack/App/ContentView.swift
@@ -226,17 +226,17 @@ struct ContentView: View {
             Spacer()
 
             VStack(spacing: 16) {
-                Text("Point your phone\nat something.")
+                Text("Your captures\nlive here.")
                     .font(.system(size: 28, weight: .black))
                     .multilineTextAlignment(.center)
                     .foregroundStyle(QSColor.onSurface)
 
-                Text("Something happens.")
+                Text("Snap your first one.")
                     .font(.system(size: 28, weight: .black))
                     .foregroundStyle(QSColor.onSurfaceVariant)
             }
 
-            Text("Receipts, flyers, notes, business cards —\nQuillStack reads it, tags it, does something with it.")
+            Text("Receipts, flyers, notes, business cards —\nQuillStack reads them, suggests tags, and surfaces quick actions.")
                 .font(QSFont.sans(size: 15))
                 .multilineTextAlignment(.center)
                 .foregroundStyle(QSColor.onSurfaceMuted)


### PR DESCRIPTION
Replaces the placeholder empty-state copy on the timeline (`ContentView.swift`).

**Before**
> Point your phone / at something.
> Something happens.
> Receipts, flyers, notes, business cards — QuillStack reads it, tags it, **does something with it.**

**After**
> Your captures / live here.
> Snap your first one.
> Receipts, flyers, notes, business cards — QuillStack reads them, suggests tags, and surfaces quick actions.

Orients a first-run user (what the screen becomes + the first action) and makes the subtitle concrete instead of placeholder voice. Layout, fonts, and the numbered 3-step guide below are unchanged. Verified with a Debug simulator build (`** BUILD SUCCEEDED **`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)