### PR TITLE
fix(cloudkit): Push Notifications entitlement, per-config entitlements, pinned team

### DIFF
--- a/QuillStack.xcodeproj/project.pbxproj
+++ b/QuillStack.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		E9ACD9D237539FE98A517F0C /* CaptureImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BDD1012BB13C6FEEFD5AD9A /* CaptureImage.swift */; };
 		EC6A6244A74C8C00DA961B46 /* OCRTextSectionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF9861103633A47D3918999A /* OCRTextSectionUITests.swift */; };
 		F1201C13E23112CB33A6A34A /* ObsidianExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A958B641DDBAE7634C36E276 /* ObsidianExporter.swift */; };
+		F5F66EFB29731C6D79EF2C00 /* CloudKitSyncMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = F486CFFAF2AB54660DEC760A /* CloudKitSyncMonitor.swift */; };
 		F82CA7DE8A8CBAFEA3514940 /* QuillStackUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F49090AA5E910A9D4502F4BD /* QuillStackUITests.swift */; };
 		F8446781AF15E4615A2631CA /* CrashReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E02039CCDB58AA737CF6A1E /* CrashReporting.swift */; };
 		F84F3E76BE7F7ABC56DA086B /* StorageUnavailableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C58417BCD34A8A64E1FCF0 /* StorageUnavailableView.swift */; };
@@ -129,6 +130,7 @@
 		DFB6CBB1585D65A2820B654D /* AITagChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AITagChip.swift; sourceTree = "<group>"; };
 		EF9861103633A47D3918999A /* OCRTextSectionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OCRTextSectionUITests.swift; sourceTree = "<group>"; };
 		F27989E6270109F7FFBD2EAF /* EnrichmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnrichmentTests.swift; sourceTree = "<group>"; };
+		F486CFFAF2AB54660DEC760A /* CloudKitSyncMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudKitSyncMonitor.swift; sourceTree = "<group>"; };
 		F49090AA5E910A9D4502F4BD /* QuillStackUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuillStackUITests.swift; sourceTree = "<group>"; };
 		FD6499B4EDA579471C027B8B /* QuillStackApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuillStackApp.swift; sourceTree = "<group>"; };
 		FD81AE056AC7E1A2498C619A /* Enrichment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Enrichment.swift; sourceTree = "<group>"; };
@@ -326,6 +328,7 @@
 			children = (
 				537015B16D0EED6B6DBAB9A6 /* CaptureProcessor.swift */,
 				D7FE444B2A567385036B273D /* CaptureReprocessor.swift */,
+				F486CFFAF2AB54660DEC760A /* CloudKitSyncMonitor.swift */,
 				3E02039CCDB58AA737CF6A1E /* CrashReporting.swift */,
 				5C21F408FCDD056482FDC727 /* LocationService.swift */,
 				A958B641DDBAE7634C36E276 /* ObsidianExporter.swift */,
@@ -493,6 +496,7 @@
 				E9ACD9D237539FE98A517F0C /* CaptureImage.swift in Sources */,
 				467CFA561DFF4886DCCBEE48 /* CaptureProcessor.swift in Sources */,
 				8E83ED6F75D0B9E55D8B582E /* CaptureReprocessor.swift in Sources */,
+				F5F66EFB29731C6D79EF2C00 /* CloudKitSyncMonitor.swift in Sources */,
 				74CFA93B5B14CAA49F511DC7 /* ContactActionView.swift in Sources */,
 				C3AA5AB93657990DA5182634 /* ContactExtraction.swift in Sources */,
 				55932922712289AB36418C79 /* ContentView.swift in Sources */,

--- a/QuillStack.xcodeproj/project.pbxproj
+++ b/QuillStack.xcodeproj/project.pbxproj
@@ -109,7 +109,6 @@
 		7BDD1012BB13C6FEEFD5AD9A /* CaptureImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureImage.swift; sourceTree = "<group>"; };
 		7E04295D9BFF151B35D4EDF0 /* StorageRecoveryUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageRecoveryUITests.swift; sourceTree = "<group>"; };
 		817E6AAE6434F0F869ED3954 /* QuillStack.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = QuillStack.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		82554B68A8D4B7351B5E70C9 /* QuillStack.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = QuillStack.entitlements; sourceTree = "<group>"; };
 		830DBB50D82C00865610C70E /* ActionIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionIcon.swift; sourceTree = "<group>"; };
 		83C0D238F4C235D80F4AB568 /* OnDeviceEnrichmentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnDeviceEnrichmentService.swift; sourceTree = "<group>"; };
 		84704540B805D88979BF52CD /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
@@ -242,7 +241,6 @@
 			children = (
 				3FB76058408D13419B7BE321 /* Assets.xcassets */,
 				2AE00E011597807C677D8713 /* PrivacyInfo.xcprivacy */,
-				82554B68A8D4B7351B5E70C9 /* QuillStack.entitlements */,
 				1259D777AD7D35451FCEDC2A /* App */,
 				E846F93AD9E4D1ECB67861D1 /* Models */,
 				3EECED0CADFB246418452A4C /* Resources */,
@@ -406,7 +404,14 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					02B2FAA4FE826727BB4A1349 = {
+						DevelopmentTeam = HZQB6JS358;
+					};
+					538F8570D1E027322DE80B8A = {
+						DevelopmentTeam = HZQB6JS358;
+					};
 					E42AB247E38CBD58E3C8FB84 = {
+						DevelopmentTeam = HZQB6JS358;
 						TestTargetID = 02B2FAA4FE826727BB4A1349;
 					};
 				};
@@ -561,7 +566,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
-				CODE_SIGN_ENTITLEMENTS = QuillStack/QuillStack.entitlements;
+				CODE_SIGN_ENTITLEMENTS = QuillStack/QuillStack.Debug.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DWARF_DSYM_FILE_SHOULD_ACCOMPANY_PRODUCT = NO;
@@ -629,6 +634,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = HZQB6JS358;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -693,6 +699,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = HZQB6JS358;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
@@ -720,7 +727,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = YES;
-				CODE_SIGN_ENTITLEMENTS = QuillStack/QuillStack.entitlements;
+				CODE_SIGN_ENTITLEMENTS = QuillStack/QuillStack.Release.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
 				DWARF_DSYM_FILE_SHOULD_ACCOMPANY_PRODUCT = NO;

--- a/QuillStack/App/QuillStackApp.swift
+++ b/QuillStack/App/QuillStackApp.swift
@@ -30,6 +30,9 @@ struct QuillStackApp: App {
     init() {
         if !Self.isUITesting {
             CrashReporting.start()
+            // Registered before the container is built, or the `setup` event —
+            // the one that carries container/entitlement failures — is missed.
+            MainActor.assumeIsolated { CloudKitSyncMonitor.shared.start() }
         }
         _store = State(initialValue: Self.loadStore())
     }

--- a/QuillStack/QuillStack.Debug.entitlements
+++ b/QuillStack/QuillStack.Debug.entitlements
@@ -10,5 +10,13 @@
 	<array>
 		<string>CloudKit</string>
 	</array>
+	<!--
+	  NSPersistentCloudKitContainer drives sync with silent pushes, so the Push
+	  Notifications capability is required alongside the remote-notification
+	  background mode in Info.plist. Must be "development" for Xcode builds.
+	  No icloud-container-environment here: dev builds default to Development.
+	-->
+	<key>aps-environment</key>
+	<string>development</string>
 </dict>
 </plist>

--- a/QuillStack/QuillStack.Release.entitlements
+++ b/QuillStack/QuillStack.Release.entitlements
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.quillstack.app</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
+	<!-- TestFlight and App Store builds must use the production APS environment. -->
+	<key>aps-environment</key>
+	<string>production</string>
+	<!--
+	  Archived builds must be told to target the Production CloudKit environment.
+	  Without this an archive can still talk to Development, so TestFlight would
+	  read a database that real users never write to.
+	-->
+	<key>com.apple.developer.icloud-container-environment</key>
+	<string>Production</string>
+</dict>
+</plist>

--- a/QuillStack/Services/CloudKitSyncMonitor.swift
+++ b/QuillStack/Services/CloudKitSyncMonitor.swift
@@ -1,0 +1,121 @@
+import Foundation
+import CoreData
+import os
+
+/// SwiftData mirrors to CloudKit through `NSPersistentCloudKitContainer`, which
+/// posts every setup / import / export event — including the error that caused a
+/// failure — on the default NotificationCenter. Nothing observed it, so CloudKit
+/// failures were completely invisible: the app looked healthy while syncing
+/// nothing. This is the same silent-failure pattern as the `catch` that
+/// downgraded the container to local-only.
+@MainActor
+@Observable
+final class CloudKitSyncMonitor {
+
+    static let shared = CloudKitSyncMonitor()
+
+    struct Status: Sendable, Equatable {
+        var eventType: String
+        var succeeded: Bool
+        var date: Date
+        /// On-device display only. Never transmitted — may embed identifiers.
+        var errorDescription: String?
+        /// CKError.partialFailure hides the real cause in partialErrorsByItemID,
+        /// which localizedDescription discards. Keep the underlying detail.
+        var errorDetail: String?
+    }
+
+    private(set) var lastStatus: Status?
+    private(set) var lastFailure: Status?
+
+    private var observer: NSObjectProtocol?
+    private let logger = Logger(subsystem: "com.quillstack", category: "CloudKitSync")
+
+    private init() {}
+
+    func start() {
+        guard observer == nil else { return }
+        observer = NotificationCenter.default.addObserver(
+            forName: NSPersistentCloudKitContainer.eventChangedNotification,
+            object: nil,
+            queue: .main
+        ) { note in
+            guard
+                let event = note.userInfo?[NSPersistentCloudKitContainer.eventNotificationUserInfoKey]
+                    as? NSPersistentCloudKitContainer.Event,
+                event.endDate != nil          // only completed events
+            else { return }
+
+            let status = Status(
+                eventType: Self.name(for: event.type),
+                succeeded: event.succeeded,
+                date: event.endDate ?? .now,
+                errorDescription: event.error?.localizedDescription,
+                errorDetail: event.error.map { Self.detail(for: $0) }
+            )
+
+            // addObserver(queue: .main) guarantees main-thread delivery.
+            MainActor.assumeIsolated {
+                Self.shared.record(status)
+            }
+        }
+    }
+
+    private func record(_ status: Status) {
+        lastStatus = status
+        if !status.succeeded {
+            lastFailure = status
+            logger.error("CloudKit \(status.eventType) failed: \(status.errorDescription ?? "unknown")")
+        } else {
+            logger.info("CloudKit \(status.eventType) succeeded")
+        }
+
+        #if DEBUG
+        // os_log cannot be read from an attached device without root; stdout can
+        // (`devicectl device process launch --console`). Debug builds only.
+        print("[CloudKitSync] \(status.eventType) succeeded=\(status.succeeded) error=\(status.errorDescription ?? "none")")
+        if let detail = status.errorDetail {
+            print("[CloudKitSync] detail: \(detail)")
+        }
+        #endif
+    }
+
+    /// A CKError.partialFailure can carry the per-zone cause in userInfo, so walk
+    /// it and recurse into nested NSErrors rather than relying on
+    /// localizedDescription, which discards them.
+    ///
+    /// Note: for the `setup` event the error arrives with an empty userInfo
+    /// (`CKErrorDomain code=2 "(null)"`). The detailed per-zone reason is only
+    /// emitted to CoreData's os_log, not through this notification.
+    nonisolated private static func detail(for error: Error, depth: Int = 0) -> String {
+        let ns = error as NSError
+        let pad = String(repeating: "  ", count: depth)
+        var out = "\(pad)\(ns.domain) code=\(ns.code)"
+
+        guard depth < 3 else { return out }
+
+        for (key, value) in ns.userInfo {
+            if let nested = value as? NSError {
+                out += "\n\(pad)  [\(key)] →\n" + detail(for: nested, depth: depth + 2)
+            } else if let dict = value as? [AnyHashable: Any] {
+                for (innerKey, innerValue) in dict {
+                    if let nested = innerValue as? NSError {
+                        out += "\n\(pad)  [\(key)/\(innerKey)] →\n" + detail(for: nested, depth: depth + 2)
+                    }
+                }
+            } else if key == "ServerErrorDescription" || key == NSLocalizedFailureReasonErrorKey {
+                out += "\n\(pad)  \(key)=\(value)"
+            }
+        }
+        return out
+    }
+
+    nonisolated private static func name(for type: NSPersistentCloudKitContainer.EventType) -> String {
+        switch type {
+        case .setup: "setup"
+        case .import: "import"
+        case .export: "export"
+        @unknown default: "unknown"
+        }
+    }
+}

--- a/QuillStack/Views/Settings/SettingsView.swift
+++ b/QuillStack/Views/Settings/SettingsView.swift
@@ -8,6 +8,7 @@ struct SettingsView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Tag.name) private var tags: [Tag]
     @State private var locationService = LocationService()
+    private var syncMonitor: CloudKitSyncMonitor { .shared }
     @State private var showNewTag = false
     @State private var newTagName = ""
     @State private var newTagColor = "#6B7280"
@@ -295,15 +296,18 @@ struct SettingsView: View {
             sectionHeader("ICLOUD BACKUP")
 
             VStack(spacing: 0) {
-                settingsRow("Status") {
+                // An iCloud account existing says nothing about whether mirroring
+                // works. Report the last real CloudKit event instead.
+                settingsRow("Sync") {
                     HStack(spacing: 6) {
                         Circle()
                             .fill(QSColor.onSurfaceMuted)
                             .frame(width: 8, height: 8)
-                            .opacity(icloudAvailable ? 1.0 : 0.3)
-                        Text(icloudAvailable ? "Active" : "Unavailable")
+                            .opacity(syncMonitor.lastStatus?.succeeded == true ? 1.0 : 0.3)
+                        Text(syncStatusLabel)
                             .font(QSFont.mono(size: 13))
                             .foregroundStyle(QSColor.onSurfaceMuted)
+                            .accessibilityIdentifier("icloud-sync-status")
                     }
                 }
 
@@ -316,11 +320,38 @@ struct SettingsView: View {
             .background(QSSurface.container)
             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
 
+            if let failure = syncMonitor.lastFailure {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("LAST SYNC ERROR — \(failure.eventType.uppercased())")
+                        .font(QSFont.mono(size: 9))
+                        .fontWeight(.bold)
+                        .tracking(1.5)
+                        .foregroundStyle(QSColor.onSurfaceMuted)
+
+                    Text(failure.errorDescription ?? "Unknown error")
+                        .font(QSFont.monoLight(size: 11))
+                        .foregroundStyle(QSColor.onSurfaceVariant)
+                        .textSelection(.enabled)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .accessibilityIdentifier("icloud-sync-error")
+                }
+                .padding(12)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(QSSurface.container)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+
             Text("Captures and tags sync to iCloud automatically. Data restores when you reinstall.")
                 .font(QSFont.monoLight(size: 11))
                 .foregroundStyle(QSColor.onSurfaceMuted)
                 .padding(.leading, 4)
         }
+    }
+
+    private var syncStatusLabel: String {
+        guard icloudAvailable else { return "No Account" }
+        guard let status = syncMonitor.lastStatus else { return "Waiting…" }
+        return status.succeeded ? "Active" : "Failed"
     }
 
     // MARK: - About

--- a/project.yml
+++ b/project.yml
@@ -7,6 +7,10 @@ options:
 settings:
   SWIFT_VERSION: "6.0"
   SWIFT_STRICT_CONCURRENCY: complete
+  # Pinned here, not left to Xcode. Xcode writes DEVELOPMENT_TEAM back into
+  # project.pbxproj, which `xcodegen generate` then discards — signing silently
+  # drifts, and CloudKit rejects a container owned by a different team.
+  DEVELOPMENT_TEAM: HZQB6JS358
 packages:
   Sentry:
     url: https://github.com/getsentry/sentry-cocoa.git
@@ -20,6 +24,7 @@ targets:
       - path: QuillStack
         excludes:
           - Info.plist
+          - "*.entitlements"
     settings:
       base:
         INFOPLIST_FILE: QuillStack/Info.plist
@@ -29,7 +34,14 @@ targets:
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS: YES
         DWARF_DSYM_FILE_SHOULD_ACCOMPANY_PRODUCT: NO
-        CODE_SIGN_ENTITLEMENTS: QuillStack/QuillStack.entitlements
+      configs:
+        # aps-environment and icloud-container-environment must differ between
+        # a local Xcode build (Development CloudKit) and an archive bound for
+        # TestFlight (Production CloudKit). One entitlements file cannot do both.
+        Debug:
+          CODE_SIGN_ENTITLEMENTS: QuillStack/QuillStack.Debug.entitlements
+        Release:
+          CODE_SIGN_ENTITLEMENTS: QuillStack/QuillStack.Release.entitlements
     preBuildScripts:
       - script: |
           if command -v swiftlint >/dev/null 2>&1; then


### PR DESCRIPTION
Found while diagnosing `CKError 10/2007` ("Invalid bundle ID for container") on device.

## 1. Missing `aps-environment`

`NSPersistentCloudKitContainer` drives sync with silent pushes, so Apple requires the Push Notifications capability. `Info.plist` already declared `UIBackgroundModes: remote-notification` — the half that needs no entitlement — but `aps-environment` was absent entirely.

Note: the `/ship` audit flagged that background mode as an *unused capability to remove*. That was wrong. It is half of the CloudKit push requirement, and removing it would have broken sync in a hard-to-trace way.

Zone setup creates a CloudKit subscription, which is validated against the app's entitlements server-side. An app without `aps-environment` cannot hold a push subscription — consistent with a permission failure scoped to `zoneName=com.apple.coredata.cloudkit.zone`.

**Requires** enabling the Push Notifications capability on App ID `com.quillstack.app` in the developer portal, or signing will fail.

## 2. One entitlements file cannot serve both environments

- `aps-environment` must be `development` for Xcode builds, `production` for TestFlight/App Store.
- Archives need `com.apple.developer.icloud-container-environment = Production`, or a TestFlight build talks to the **Development** CloudKit database that real users never write to.

Split into `QuillStack.Debug.entitlements` / `QuillStack.Release.entitlements`, wired per configuration. `*.entitlements` is now excluded from the sources glob so the inactive config's file can't be copied into the bundle as a resource.

## 3. `DEVELOPMENT_TEAM` was not in `project.yml`

It lived only in `project.pbxproj`, where Xcode writes it back after each open — and `xcodegen generate` discards it. Signing drifted silently between regenerations, and CloudKit rejects a container owned by a different team. Now pinned (`HZQB6JS358`).

## Verification

- Resolved `CODE_SIGN_ENTITLEMENTS` differs per configuration (checked via `-showBuildSettings`)
- Both entitlement plists lint
- `DEVELOPMENT_TEAM` survives `xcodegen generate`
- Debug + Release build; CI build command passes
- 57 unit tests, 24 UI tests

## Scope

Signing was never the cause of `10/2007` — the embedded profile already granted `iCloud.com.quillstack.app` for team `HZQB6JS358`, and the container is provisioned in CloudKit Console. These are three genuine defects that would each have bitten later; whether they clear the runtime error is confirmed by rebuilding on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app signing settings for more reliable builds and releases.
  * Separated development and release configuration so each build uses the correct service environment.
  * Improved support for cloud sync and push notifications in development and production builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->